### PR TITLE
Bug/fix zooming function

### DIFF
--- a/Client/src/Components/Graph/Graph.js
+++ b/Client/src/Components/Graph/Graph.js
@@ -86,8 +86,7 @@ export default function Graph(props) {
       .attr("width", width)
       .attr("height", height)
       .style("pointer-events", "all")
-      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
-      .call(zoom)
+      .call(zoom);
 
     //This is the part that creates the points
     let scatter = svg.append("g")


### PR DESCRIPTION
Removed a line in the Graph page that caused the zooming rectangle to be slightly shifted. Now you can zoom in and out on any part of the graph.