### PR TITLE
Fixed environment variable for windows users

### DIFF
--- a/Server/src/loaders/loadStartupProcess.ts
+++ b/Server/src/loaders/loadStartupProcess.ts
@@ -1,10 +1,10 @@
-import express from 'express';
 import 'dotenv/config';
-import cors from 'cors';
-import { connectDB } from '../database'
-import { fileUploadRouter } from '../routes/fileUploadRouter'
-import bodyParser from 'body-parser'
 
+import bodyParser from 'body-parser'
+import { connectDB } from '../database'
+import cors from 'cors';
+import express from 'express';
+import { fileUploadRouter } from '../routes/fileUploadRouter'
 
 /**
  * This class contains complete startup procedure of the application. These settings are loaded only once and used
@@ -55,7 +55,7 @@ export class loadStartupProcess {
       "type": process.env.DB_TYPE,
       "host": process.env.HOST,
       "port": process.env.DB_PORT,
-      "username": process.env.USERNAME,
+      "username": process.env.USER_NAME,
       "password": process.env.PASSWORD,
       "database": process.env.DB_NAME,
       "synchronize": true,
@@ -83,7 +83,12 @@ export class loadStartupProcess {
 
 
     (async () => {
-      await connectDB(config);
+      try {
+        await connectDB(config);
+      } catch (error) {
+        console.log("caught error while connecting to db:")
+        console.log(error)
+      }
       await startServer();
     })();
 


### PR DESCRIPTION
Windows would have its own environment variable USERNAME and would it would break the code that relies on USERNAME variable, so changing it to USER_NAME to avoid conflict