### PR TITLE
Backend/#53 query data sets

### DIFF
--- a/Server/ormconfig.js
+++ b/Server/ormconfig.js
@@ -1,0 +1,17 @@
+module.exports = {
+    name: 'default',
+    "type": process.env.TEST_DB_TYPE,
+    "host": process.env.TEST_HOST,
+    "port": process.env.TEST_DB_PORT,
+    "username": process.env.TEST_USER_NAME,
+    "password": process.env.TEST_PASSWORD,
+    "database": process.env.TEST_DB_NAME,
+    "synchronize": true,
+    "logging": false,
+    "entities": [
+        '../models/entities/**/*.ts',
+        '../models/entities/*.ts',
+        "src/models/entities/**/*.ts",
+        "dist/entities/**/*.js"
+    ]
+}

--- a/Server/src/controllers/getDataController.ts
+++ b/Server/src/controllers/getDataController.ts
@@ -1,25 +1,42 @@
+import { Request, Response } from 'express';
 import { retrieveData } from '../services/getDataService';
 import { IDataRequestModel } from "../models/interfaces/DataRequestModelInterface";
 
 export class getDataController {
+    private validatedRequest: IDataRequestModel;
+    constructor() {
+    }
     async createRequestForData(request: Request, response: Response) {
-        let validatedData = this.validateInputData(request, response);
-        try {
-            const retrieveDataObject = new retrieveData();
-            let arrayOfData = await retrieveDataObject.getArrayOfDatasets(validatedData)
-            return response.status(200).send(arrayOfData);
-        } catch (err) {
-            response.status(500).send(err);
+        let validateData = this.validateInputData(request)
+        console.log(validateData)
+        if (!validateData) {
+            response.status(500).send("Invalid search params entered");
+        }
+        else {
+            this.validatedRequest = {} as any;
+            this.validatedRequest.datasetId = request.query.datasetId as any[];
+            this.validatedRequest.material = request.query.material as string[];
+            this.validatedRequest.year = request.query.year as any;
+            this.validatedRequest.firstName = request.query.firstName as string;
+            this.validatedRequest.lastName = request.query.lastName as string;
+            this.validatedRequest.categoryId = request.query.categoryId as any;
+            this.validatedRequest.subcategoryId = request.query.datasetId as any;
+            try {
+                const retrieveDataObject = new retrieveData();
+                let arrayOfData = await retrieveDataObject.getArrayOfDatasets(this.validatedRequest)
+                return response.status(200).send(arrayOfData);
+            } catch (err) {
+                response.status(500).send(err);
+            }
         }
     }
 
-    private validateInputData(request: Request, response: Response) {
-        let validatedRequest: IDataRequestModel;
-        validatedRequest = request.query;
-        if (validatedRequest.datasetId != undefined && validatedRequest.material.length > 0
-            && validatedRequest.year != undefined && validatedRequest.categoryId != undefined
-            && (validatedRequest.firstName != undefined || validatedRequest.lastName != undefined))
-            response.status(500).send("Invalid search params entered");
-        return validatedRequest
+    private validateInputData(request: Request) {
+        if (request.query.hasOwnProperty('datasetId') || request.query.hasOwnProperty('material')
+            || request.query.hasOwnProperty('year') || request.query.hasOwnProperty('categoryId')
+            || (request.query.hasOwnProperty('firstName') && request.query.hasOwnProperty('lastName'))) { return true }
+        else {
+            return false
+        }
     }
 }

--- a/Server/src/controllers/getDataController.ts
+++ b/Server/src/controllers/getDataController.ts
@@ -3,7 +3,7 @@ import { retrieveData } from '../services/getDataService';
 import { IDataRequestModel } from "../models/interfaces/DataRequestModelInterface";
 
 export class getDataController {
-    private validatedRequest: IDataRequestModel;
+    private processedRequest: IDataRequestModel;
     constructor() {
     }
     /**
@@ -23,17 +23,11 @@ export class getDataController {
             response.status(500).send("Invalid search params entered");
         }
         else {
-            this.validatedRequest = {} as any;
-            this.validatedRequest.datasetId = request.query.datasetId as any[];
-            this.validatedRequest.material = request.query.material as string[];
-            this.validatedRequest.year = request.query.year as any;
-            this.validatedRequest.firstName = request.query.firstName as string;
-            this.validatedRequest.lastName = request.query.lastName as string;
-            this.validatedRequest.categoryId = request.query.categoryId as any;
-            this.validatedRequest.subcategoryId = request.query.subcategoryId as any;
+            let requestParams: any = { ...request.query };
+            this.processedRequest = requestParams;
             try {
                 const retrieveDataObject = new retrieveData();
-                let arrayOfData = await retrieveDataObject.getArrayOfDatasets(this.validatedRequest)
+                let arrayOfData = await retrieveDataObject.getArrayOfDatasets(this.processedRequest)
                 return response.status(200).send(arrayOfData);
             } catch (err) {
                 response.status(500).send(err);

--- a/Server/src/controllers/getDataController.ts
+++ b/Server/src/controllers/getDataController.ts
@@ -6,9 +6,19 @@ export class getDataController {
     private validatedRequest: IDataRequestModel;
     constructor() {
     }
+    /**
+     * This controller will take a request, verify that it is valid, and if it valid will then process the request,
+     * send it to the getDataService to acquire an array of data sets that match the entered search terms, and
+     * then return a response with the array of data sets. If the request is invalid, or some other problem arrises, 
+     * it will throw an error.
+     * 
+     * @param request
+     * An object containing the request information and parameters: Request 
+     * @param response 
+     * An object containing a response: Response
+     */
     async createRequestForData(request: Request, response: Response) {
         let validateData = this.validateInputData(request)
-        console.log(validateData)
         if (!validateData) {
             response.status(500).send("Invalid search params entered");
         }
@@ -20,7 +30,7 @@ export class getDataController {
             this.validatedRequest.firstName = request.query.firstName as string;
             this.validatedRequest.lastName = request.query.lastName as string;
             this.validatedRequest.categoryId = request.query.categoryId as any;
-            this.validatedRequest.subcategoryId = request.query.datasetId as any;
+            this.validatedRequest.subcategoryId = request.query.subcategoryId as any;
             try {
                 const retrieveDataObject = new retrieveData();
                 let arrayOfData = await retrieveDataObject.getArrayOfDatasets(this.validatedRequest)
@@ -31,6 +41,13 @@ export class getDataController {
         }
     }
 
+    /**
+     * This method verifies that a request has at least one valid search parameter and returns true if so
+     * and false if not.
+     * 
+     * @param request 
+     * An object containing the request information and parameters: Request
+     */
     private validateInputData(request: Request) {
         if (request.query.hasOwnProperty('datasetId') || request.query.hasOwnProperty('material')
             || request.query.hasOwnProperty('year') || request.query.hasOwnProperty('categoryId')

--- a/Server/src/models/DataQueryModel.ts
+++ b/Server/src/models/DataQueryModel.ts
@@ -31,7 +31,6 @@ export class DataQueryModel {
      * A string containing either a material's composition or details: string
      */
     async getDatasetIDFromMaterial(material: string): Promise<IDatasetModel[]> {
-        // Get composition ID if a compostion was entered instead of material details
         let compositionIdRaw = await this.connection.manager.find(Composition, { composition: material });
         let compositionId = -1; // fallback value if material details were entered
         if (compositionIdRaw[0] != null) {

--- a/Server/src/models/DataQueryModel.ts
+++ b/Server/src/models/DataQueryModel.ts
@@ -20,6 +20,16 @@ export class DataQueryModel {
         this.connection = getConnection();
     }
 
+    /**
+     * This method will run a query find all the data set IDs based on an entered material
+     * and return a raw data packet containing that information. 
+     * Before running this query, there will be a check done to see if a composition was entered
+     * and will grab the composition foreign key ID, to use both this ID and the original string  
+     * as search terms in the query.
+     * 
+     * @param material 
+     * A string containing either a material's composition or details: string
+     */
     async getDatasetIDFromMaterial(material: string): Promise<IDatasetModel[]> {
         // Get composition ID if a compostion was entered instead of material details
         let compositionIdRaw = await this.connection.manager.find(Composition, { composition: material });
@@ -36,6 +46,13 @@ export class DataQueryModel {
         return materialDatasetData;
     }
 
+    /**
+     * This method will run a query find all the data set IDs based on an entered year
+     * and return a raw data packet containing that information. 
+     * 
+     * @param year 
+     * Publication year: number
+     */
     async getDatasetIDFromYear(year: number): Promise<IDatasetModel[]> {
         let yearDatasetData: IDatasetModel[] = await selectDatasetIdsQuery(this.connection.manager)
             .innerJoin(Publications, 'publication', 'dataset.publicationId = publication.id')
@@ -44,6 +61,17 @@ export class DataQueryModel {
         return yearDatasetData;
     }
 
+    /**
+     * This method will run a query find all the data set IDs based on an entered author's name
+     * and return a raw data packet containing that information. 
+     * This specific query will work if even if an author's name is entered in reverse, 
+     * i.e. if a first name was entered as a last name and the last name was entered as a first name.
+     * 
+     * @param firstName 
+     * The first name of an author: string
+     * @param lastName 
+     * The last name of an author: string
+     */
     async getDatasetIDFromAuthor(firstName: string, lastName: string): Promise<IDatasetModel[]> {
         let authorDatasetData: IDatasetModel[] = await selectDatasetIdsQuery(this.connection.manager)
             .innerJoin(Publications, 'publication', 'dataset.publicationId = publication.id')
@@ -55,6 +83,13 @@ export class DataQueryModel {
         return authorDatasetData;
     }
 
+    /**
+     * This method will run a query find all the data set IDs based on an entered category ID
+     * and return a raw data packet containing that information. 
+     * 
+     * @param category
+     * A category ID: number
+     */
     async getDatasetIDFromCategory(category: number): Promise<IDatasetModel[]> {
         let categoryDatasetData: IDatasetModel[] = await selectDatasetIdsQuery(this.connection.manager)
             .innerJoin(Category, 'category', 'dataset.categoryId = category.id')
@@ -63,6 +98,15 @@ export class DataQueryModel {
         return categoryDatasetData;
     }
 
+    /**
+     * This method will run a query find all the data set IDs based on an entered category ID plus
+     * a suncategory ID and return a raw data packet containing that information. 
+     * 
+     * @param category 
+     * A category ID: number
+     * @param subcategory 
+     * A subcategory ID: number
+     */
     async getDatasetIDFromSubcategory(category: number, subcategory: number): Promise<IDatasetModel[]> {
         let subcategoryDatasetData: IDatasetModel[] = await selectDatasetIdsQuery(this.connection.manager)
             .innerJoin(Category, 'category', 'dataset.categoryId = category.id')
@@ -72,6 +116,15 @@ export class DataQueryModel {
             .getRawMany();
         return subcategoryDatasetData;
     }
+
+    /**
+     * This method takes a data set ID, runs 6 queries to get the publication, author, data set, material,
+     * data point, and data point comment information corresponding to this data set ID. The returns of these
+     * 6 queries are then combined into a single IDatasetResponseModel object and subsiquently returned.
+     * 
+     * @param id 
+     * A data set ID: number
+     */
     async getAllData(id: number): Promise<IDatasetResponseModel> {
         let publicationData: IPublicationModel[] = await selectPublicationsQuery(this.connection.manager, id)
         let authorData: IAuthorModel[] = await selectAuthorsQuery(this.connection.manager, id)

--- a/Server/src/models/interfaces/DataRequestModelInterface.ts
+++ b/Server/src/models/interfaces/DataRequestModelInterface.ts
@@ -1,5 +1,5 @@
 export interface IDataRequestModel {
-    datasetId: number
+    datasetId: number[]
     material: string[]
     firstName: string
     lastName: string

--- a/Server/src/routes/queryDataRouter.ts
+++ b/Server/src/routes/queryDataRouter.ts
@@ -2,14 +2,14 @@ import { Request, Response, Router } from 'express';
 import { getDataController } from '../controllers/getDataController';
 
 /**
- * This file contains the routes for a call to query or obtain a dataset. 
- * If an API call is made to /getData then the request is routed to the getDataController
+ * This file contains the route for a call to query or obtain one or more data sets. 
+ * If an API call is made to /dataset* then the request is routed to the getDataController
  * to continue processing of the request.
  */
 
 let router = Router();
 
-router.get('/dataset*', (request: Request, response, Response) => {
+router.get('/dataset*', (request: Request, response: Response) => {
     let getDataControllerObject = new getDataController();
     getDataControllerObject.createRequestForData(request, response);
 });

--- a/Server/src/services/getDataService.ts
+++ b/Server/src/services/getDataService.ts
@@ -169,7 +169,6 @@ export class retrieveData {
      * This is an array containing the data set IDs that we wish to get the full data set of: any[]
      */
     private async getDataFromDatasetIds(selectedDatasetIds: any[]) {
-        // Query each data set ID to get its information and add to array of data
         let setOfData: Array<IDatasetResponseModel> = [];
         for (let i = 0; i < selectedDatasetIds.length; i++) {
             setOfData.push(await this.dataQuery.getAllData(selectedDatasetIds[i]));

--- a/Server/src/services/getDataService.ts
+++ b/Server/src/services/getDataService.ts
@@ -9,16 +9,34 @@ export class retrieveData {
         this.dataQuery = new DataQueryModel();
     }
 
+    /**
+     * This is the 'main' method of database searches. It receives all the data and then it does a check if it 
+     * was given an array of data set IDs. If it did not receive an array of data set IDs, 
+     * it will call @getDatasetIdsFromParams to grab an array of data set IDs based on the various search
+     * parameters (materials, authors, category, and/or subcategory). Then with the newly generated array of 
+     * data set IDs, or if such an array was received at the beginning, this method will then call 
+     * @getDataFromDatasetIds for retreving the information of the data sets themselves.
+     * 
+     * @param receivedData 
+     * This param is an object of type IDataRequestModel. 
+     * It contains all the sorted search parameters, that being any combination of the following:
+     * An array of data set IDs: number[]
+     * An array of materials, where each material is either the composition or the material details: string[]
+     * The first name of an author: string
+     * The last name of an author: string 
+     * Publication year: number
+     * A category ID: number
+     * A subcategory ID: number
+     */
     async getArrayOfDatasets(receivedData: IDataRequestModel) {
         let datasetReceived = receivedData.datasetId;
         let materialReceived = receivedData.material;
-        console.log(receivedData.material);
         let firstNameReceived = receivedData.firstName;
         let lastNameReceived = receivedData.lastName;
         let yearReceived = receivedData.year;
         let categoryReceived = receivedData.categoryId;
         let subcategoryReceived = receivedData.subcategoryId;
-        let selectedDatasetIds = [datasetReceived];
+        let selectedDatasetIds = datasetReceived;
         if (datasetReceived == undefined) {
             selectedDatasetIds = await this.getDatasetIdsFromParams(materialReceived, yearReceived, firstNameReceived, lastNameReceived, categoryReceived, subcategoryReceived)
         }
@@ -26,13 +44,45 @@ export class retrieveData {
         return setOfData;
     }
 
+    /**
+     * This method is used to get an array of data set IDs that match all the entered search parameters. 
+     * Notably at the beginning it declares paramsEntered, which is a number value that will keep 
+     * track of how many search parameters were entered, and rawDatasetIds which is an array that will
+     * contain the unsorted data set IDs that are connected to each individual parameter.
+     * 
+     * After this, for each parameter the method will check if the parameter is defined and then 
+     * for each valid value it shall increment paramsEntered, call a query to get a raw data packet 
+     * which contains the data set IDs of this parameter, and then it will feed this raw data packet to 
+     * @createDatasetIdArray to get an array of data set IDs and append this new array to rawDatasetIds.
+     * 
+     * It is worth noting that a array of materials are received, and thus that entire array is looped
+     * through to check all included materials, each check using the process described above. 
+     * For subcategory, that parameter is always paired with a category, and thus when a
+     * category is defined there is a second check to see if a subcategory is included, and will run
+     * a different query to the data base if so.
+     * 
+     * Once all the parameters have been analyzed, the paramsEntered and rawDatasetIds are passed to
+     * the @selectDatasetIds method to generate an array containing all the common data set IDs among
+     * the parameters.
+     * 
+     * @param materialReceived 
+     * An array of materials, where each material is either the composition or the material details: string[]
+     * @param yearReceived 
+     * Publication year: number
+     * @param firstNameReceived 
+     * The first name of an author: string
+     * @param lastNameReceived 
+     * The last name of an author: string 
+     * @param categoryReceived 
+     * A category ID: number
+     * @param subcategoryReceived 
+     * A subcategory ID: number
+     */
     private async getDatasetIdsFromParams(materialReceived: string[], yearReceived: number, firstNameReceived: string, lastNameReceived: string, categoryReceived: number, subcategoryReceived: number) {
         let rawData;
         let paramsEntered = 0;
-        // paramsEntered is used to track how many params were entered
         let rawDatasetIds = [];
 
-        // Check which variables were received and the data sets IDs linked to each variable
         if (materialReceived != undefined) {
             for (let i = 0; i < materialReceived.length; i++) {
                 paramsEntered++
@@ -64,6 +114,12 @@ export class retrieveData {
         return selectedDatasetIds
     }
 
+    /**
+     * This method accepts an array of raw data packets and iterates through the array to take each packet's
+     * data set ID and appends this number to a new array. Once the loop completes, the new array is returned.
+     * @param rawData 
+     * This is an array of raw data packets (aka. JSON objects): any[]
+     */
     private async createDatasetIdArray(rawData: any[]) {
         let datasetIdArray = [];
         for (let index = 0; index < rawData.length; index++) {
@@ -72,9 +128,20 @@ export class retrieveData {
         return datasetIdArray;
     }
 
+    /**
+     * This method takes an array of numbers, specifically data set IDs, iterates through this array, 
+     * and checks each array entry to see if the total occurances of this particular entry matches the 
+     * paramsEntered number. If there is a match, then the ID in question is one that is desired, and
+     * is appended to the selectedDatasetIds array. Once the looping is complete, the 
+     * selectedDatasetIds array is returned.
+     * 
+     * @param paramsEntered 
+     * Number that will be used to determine if a particular data set ID makes the cut: number
+     * @param rawDatasetIds 
+     * An array formed from combining multiple data set IDs arrays together: any[]
+     */
     private async selectDatasetIds(paramsEntered: number, rawDatasetIds: any[]) {
         let selectedDatasetIds = []
-        // Find the intersection of data sets IDs among all the different variables
         let count: number
         for (let i = 0; i < rawDatasetIds.length; i++) {
             count = 1;
@@ -90,6 +157,17 @@ export class retrieveData {
         return selectedDatasetIds;
     }
 
+    /**
+     * This declares an array of IDatasetResponseModel objects called setOfData and each IDatasetResponseModel 
+     * contains: a publication object, an array of author objects, a data set object, an array of material objects, 
+     * an array of data point objects, and a data point comments object.
+     * It then loops through the received array of data set IDs and runs a @getAllData query for each individual 
+     * entry in the array and appends the returned IDatasetResponseModel object to setOfData. Once the loop is 
+     * completed, setOfData is returned. 
+     *  
+     * @param selectedDatasetIds 
+     * This is an array containing the data set IDs that we wish to get the full data set of: any[]
+     */
     private async getDataFromDatasetIds(selectedDatasetIds: any[]) {
         // Query each data set ID to get its information and add to array of data
         let setOfData: Array<IDatasetResponseModel> = [];

--- a/Server/src/tests/DataQueryModel.spec.ts
+++ b/Server/src/tests/DataQueryModel.spec.ts
@@ -1,0 +1,76 @@
+import { createConnection, getConnection } from 'typeorm';
+import { DataQueryModel } from '../models/DataQueryModel';
+
+describe('data service test', () => {
+    let dataQueryModel: DataQueryModel;
+    jest.setTimeout(60000)
+
+    beforeAll(async () => {
+        await createConnection();
+        dataQueryModel = new DataQueryModel();
+    });
+
+    afterAll(async () => {
+        await getConnection().close();
+    });
+
+    test('Input material composition of O2, expect to find at least one dataset id', async done => {
+        let id = await dataQueryModel.getDatasetIDFromMaterial("O2");
+        expect(id[0].dataset_id).not.toBeUndefined()
+        done()
+    });
+
+    test('Input material details Oxygen, expect to find at least one dataset id', async done => {
+        let id = await dataQueryModel.getDatasetIDFromMaterial("Oxygen");
+        expect(id[0].dataset_id).not.toBeUndefined()
+        done()
+    });
+
+    test('Input material composition of null, expect undefined', async done => {
+        let id = await dataQueryModel.getDatasetIDFromMaterial(null);
+        expect(id[0]).toBeUndefined()
+        done()
+    });
+
+    test('Input publication year 1980, expect to find at least one dataset id', async done => {
+        let id = await dataQueryModel.getDatasetIDFromYear(1980);
+        expect(id[0].dataset_id).not.toBeUndefined()
+        done()
+    });
+
+    test('Input author with first name Stanley and last name Marsh, expect to find at least one dataset id', async done => {
+        let id = await dataQueryModel.getDatasetIDFromAuthor("Stanley", "Marsh");
+        expect(id[0].dataset_id).not.toBeUndefined()
+        done()
+    });
+
+    test('Input a category ID of 2, expect to find at least one dataset id', async done => {
+        let id = await dataQueryModel.getDatasetIDFromCategory(2);
+        expect(id[0].dataset_id).not.toBeUndefined()
+        done()
+    });
+
+    test('Input a category ID and subcategory ID of 2, expect to find at least one dataset id', async done => {
+        let id = await dataQueryModel.getDatasetIDFromSubcategory(2, 2);
+        expect(id[0].dataset_id).not.toBeUndefined()
+        done()
+    });
+
+    test('Input data set ID of 1, expect a data set with ID of 1 as part of the return', async done => {
+        let id = await dataQueryModel.getAllData(1);
+        expect(id.dataset[0].dataset_id).toBe(1)
+        done()
+    });
+
+    test('Input data set ID of -1, expect an empty return', async done => {
+        let id = await dataQueryModel.getAllData(-1);
+        expect(id.dataset[0]).toBeUndefined()
+        done()
+    });
+
+    test('Input data set ID of null, expect an empty return', async done => {
+        let id = await dataQueryModel.getAllData(null);
+        expect(id.dataset[0]).toBeUndefined()
+        done()
+    });
+})

--- a/Server/src/tests/getDataService.spec.ts
+++ b/Server/src/tests/getDataService.spec.ts
@@ -15,7 +15,7 @@ describe('data service test', () => {
     await getConnection().close();
   });
 
-  test('Feeds data set ID of 1 and expects to see a data set with ID of 1 returned', async () => {
+  test('Feeds data set ID of 1 and expects to see a data set with ID of 1 returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = [1];
@@ -27,9 +27,10 @@ describe('data service test', () => {
     testData.subcategoryId = undefined;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData[0].dataset[0].dataset_id).toEqual(1);
+    done()
   });
 
-  test('Feeds year of 1980 and expects to see at least one data set with year of 1980 returned', async () => {
+  test('Feeds year of 1980 and expects to see at least one data set with year of 1980 returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -41,9 +42,10 @@ describe('data service test', () => {
     testData.subcategoryId = undefined;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData[0].publications[0].publication_year).toEqual(1980);
+    done()
   });
 
-  test('Feeds material with composition O2 and a long detail string and expects to see those two materials', async () => {
+  test('Feeds material with composition O2 and a long detail string and expects to see those two materials', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -58,9 +60,10 @@ describe('data service test', () => {
       .toEqual(expect.objectContaining({ composition_name: "O2", material_details: "Oxygen" }));
     expect(arrayOfData[0].materials[0])
       .toEqual(expect.objectContaining({ composition_name: "C", material_details: "carbon, graphite, pressed graphite" }));
+    done()
   });
 
-  test('Feeds author info of "Stanley" and "Marsh" in correct order and expects to see the author named Stanley P. Marsh', async () => {
+  test('Feeds author info of "Stanley" and "Marsh" in correct order and expects to see the author named Stanley P. Marsh', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -73,9 +76,10 @@ describe('data service test', () => {
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData[0].authors[0])
       .toEqual(expect.objectContaining({ author_firstName: "Stanley", author_lastName: "Marsh", author_middleName: "P." }));
+    done()
   });
 
-  test('Feeds author info of "Stanley" and "Marsh" in reverse order and expects to see the author named Stanley P. Marsh', async () => {
+  test('Feeds author info of "Stanley" and "Marsh" in reverse order and expects to see the author named Stanley P. Marsh', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -88,9 +92,10 @@ describe('data service test', () => {
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData[0].authors[0])
       .toEqual(expect.objectContaining({ author_firstName: "Stanley", author_lastName: "Marsh", author_middleName: "P." }));
+    done()
   });
 
-  test('Feeds category ID of 2 and expects to see a data set with category name of cell size returned', async () => {
+  test('Feeds category ID of 2 and expects to see a data set with category name of cell size returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -102,9 +107,10 @@ describe('data service test', () => {
     testData.subcategoryId = undefined;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData[0].dataset[0].category_name).toEqual("cell size");
+    done()
   });
 
-  test('Feeds category ID of 2 and subcategory of 2 and expects to see a data set with subcategory name of width returned', async () => {
+  test('Feeds category ID of 2 and subcategory of 2 and expects to see a data set with subcategory name of width returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -116,9 +122,10 @@ describe('data service test', () => {
     testData.subcategoryId = 2;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData[0].dataset[0].subcategory_name).toEqual("width");
+    done()
   });
 
-  test('Feeds material with composition C and a year of 1980 and expects to find a data set with these values', async () => {
+  test('Feeds material with composition C and a year of 1980 and expects to find a data set with these values', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -132,9 +139,10 @@ describe('data service test', () => {
     expect(arrayOfData[0].publications[0].publication_year).toEqual(1980);
     expect(arrayOfData[0].materials[0])
       .toEqual(expect.objectContaining({ composition_name: "C" }));
+    done()
   });
 
-  test('Feeds subcategory of 2 and expects to see an empty array returned', async () => {
+  test('Feeds subcategory of 2 and expects to see an empty array returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -146,9 +154,10 @@ describe('data service test', () => {
     testData.subcategoryId = 2;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData).toEqual(expect.arrayContaining([]));
+    done()
   });
 
-  test('Feeds first name of Stanley and expects to see an empty array returned', async () => {
+  test('Feeds first name of Stanley and expects to see an empty array returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -160,9 +169,10 @@ describe('data service test', () => {
     testData.subcategoryId = undefined;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData).toEqual(expect.arrayContaining([]));
+    done()
   });
 
-  test('Feeds last name of Marsh and expects to see an empty array returned', async () => {
+  test('Feeds last name of Marsh and expects to see an empty array returned', async done => {
     let testData: IDataRequestModel;
     testData = {} as any;
     testData.datasetId = undefined;
@@ -174,5 +184,6 @@ describe('data service test', () => {
     testData.subcategoryId = undefined;
     let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
     expect(arrayOfData).toEqual(expect.arrayContaining([]));
+    done()
   });
 })

--- a/Server/src/tests/getDataService.spec.ts
+++ b/Server/src/tests/getDataService.spec.ts
@@ -1,0 +1,178 @@
+import { retrieveData } from '../services/getDataService';
+import { IDataRequestModel } from "../models/interfaces/DataRequestModelInterface";
+import { createConnection, getConnection } from 'typeorm';
+
+describe('data service test', () => {
+  let retrieveDataObject: retrieveData;
+  jest.setTimeout(60000)
+
+  beforeAll(async () => {
+    await createConnection();
+    retrieveDataObject = new retrieveData();
+  });
+
+  afterAll(async () => {
+    await getConnection().close();
+  });
+
+  test('Feeds data set ID of 1 and expects to see a data set with ID of 1 returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = [1];
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].dataset[0].dataset_id).toEqual(1);
+  });
+
+  test('Feeds year of 1980 and expects to see at least one data set with year of 1980 returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = 1980;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].publications[0].publication_year).toEqual(1980);
+  });
+
+  test('Feeds material with composition O2 and a long detail string and expects to see those two materials', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = ["O2", "carbon, graphite, pressed graphite"];
+    testData.year = undefined;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].materials[1])
+      .toEqual(expect.objectContaining({ composition_name: "O2", material_details: "Oxygen" }));
+    expect(arrayOfData[0].materials[0])
+      .toEqual(expect.objectContaining({ composition_name: "C", material_details: "carbon, graphite, pressed graphite" }));
+  });
+
+  test('Feeds author info of "Stanley" and "Marsh" in correct order and expects to see the author named Stanley P. Marsh', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = "Stanley";
+    testData.lastName = "Marsh";
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].authors[0])
+      .toEqual(expect.objectContaining({ author_firstName: "Stanley", author_lastName: "Marsh", author_middleName: "P." }));
+  });
+
+  test('Feeds author info of "Stanley" and "Marsh" in reverse order and expects to see the author named Stanley P. Marsh', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = "Marsh";
+    testData.lastName = "Stanley";
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].authors[0])
+      .toEqual(expect.objectContaining({ author_firstName: "Stanley", author_lastName: "Marsh", author_middleName: "P." }));
+  });
+
+  test('Feeds category ID of 2 and expects to see a data set with category name of cell size returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = 2;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].dataset[0].category_name).toEqual("cell size");
+  });
+
+  test('Feeds category ID of 2 and subcategory of 2 and expects to see a data set with subcategory name of width returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = 2;
+    testData.subcategoryId = 2;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].dataset[0].subcategory_name).toEqual("width");
+  });
+
+  test('Feeds material with composition C and a year of 1980 and expects to find a data set with these values', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = ["C"];
+    testData.year = 1980;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData[0].publications[0].publication_year).toEqual(1980);
+    expect(arrayOfData[0].materials[0])
+      .toEqual(expect.objectContaining({ composition_name: "C" }));
+  });
+
+  test('Feeds subcategory of 2 and expects to see an empty array returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = undefined;
+    testData.lastName = undefined;
+    testData.categoryId = undefined;
+    testData.subcategoryId = 2;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData).toEqual(expect.arrayContaining([]));
+  });
+
+  test('Feeds first name of Stanley and expects to see an empty array returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = "Stanley";
+    testData.lastName = undefined;
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData).toEqual(expect.arrayContaining([]));
+  });
+
+  test('Feeds last name of Marsh and expects to see an empty array returned', async () => {
+    let testData: IDataRequestModel;
+    testData = {} as any;
+    testData.datasetId = undefined;
+    testData.material = undefined;
+    testData.year = undefined;
+    testData.firstName = undefined;
+    testData.lastName = "Marsh";
+    testData.categoryId = undefined;
+    testData.subcategoryId = undefined;
+    let arrayOfData = await retrieveDataObject.getArrayOfDatasets(testData)
+    expect(arrayOfData).toEqual(expect.arrayContaining([]));
+  });
+})


### PR DESCRIPTION
This PR for #53 adds the ability to search an array of data set IDs, versus merely a single data set ID, adds in tests for all methods, does some final tweaks to code, and also adds in the file needed to allow for tests against a test database.