### PR TITLE
Disabling synchronize by default

### DIFF
--- a/Server/src/loaders/loadStartupProcess.ts
+++ b/Server/src/loaders/loadStartupProcess.ts
@@ -71,9 +71,8 @@ export class loadStartupProcess {
       "username": process.env.USER_NAME,
       "password": process.env.PASSWORD,
       "database": process.env.DB_NAME,
-      "synchronize": true,
+      "synchronize": false,
       "logging": true,
-      "migrationsRun": true,
       "entities": [
         "src/models/entities/**/*.ts",
         "dist/entities/**/*.js"


### PR DESCRIPTION
This disables synchronize by default for the reasons described in this Confluence report: 

https://databoom.atlassian.net/wiki/spaces/DB/pages/199327747/Report+TypeORM+Synchronization+and+Migrations+165