### PR TITLE
[#223] Sonarqube Refactoring (cleanup) for debt introduced in Sprint 4 & 5

### DIFF
--- a/Client/src/Components/DatasetUpload/ReferenceSection/AuthorRow.tsx
+++ b/Client/src/Components/DatasetUpload/ReferenceSection/AuthorRow.tsx
@@ -1,10 +1,7 @@
-import * as Yup from 'yup'
-
-import { Box, Grid, IconButton, TextField } from "@material-ui/core"
-import { FastField, Field, useFormik } from "formik"
+import { Box, Grid, IconButton } from "@material-ui/core"
+import { FastField } from "formik"
 
 import ClearIcon from '@material-ui/icons/Clear'
-import { IAuthor } from "../../../Models/Datasets/IDatasetModel"
 import { MuiTextFieldFormik } from '../../Forms/FormikFields'
 import React from 'react'
 

--- a/Client/src/Components/DatasetUpload/ReferenceSection/AuthorsList.tsx
+++ b/Client/src/Components/DatasetUpload/ReferenceSection/AuthorsList.tsx
@@ -1,7 +1,7 @@
-import { ArrayHelpers, FormikProps } from "formik"
+import { ArrayHelpers } from "formik"
 import { Grid, IconButton, Typography } from "@material-ui/core"
 import { IAuthor, defaultAuthor } from "../../../Models/Datasets/IDatasetModel"
-import React, { useState } from 'react'
+import React from 'react'
 
 import AddIcon from '@material-ui/icons/Add'
 import { AuthorRow } from "./AuthorRow"

--- a/Client/src/Components/DatasetUpload/ReferenceSection/ReferenceForm.tsx
+++ b/Client/src/Components/DatasetUpload/ReferenceSection/ReferenceForm.tsx
@@ -1,5 +1,3 @@
-import * as Yup from 'yup'
-
 import { Box, Grid, Typography } from '@material-ui/core'
 import { FastField, FieldArray } from 'formik'
 

--- a/Client/src/Tests/App.test.js
+++ b/Client/src/Tests/App.test.js
@@ -15,6 +15,6 @@ describe('App', () => {
   });
 
   it('should return a div', () => {
-    expect(wrapper.find('div').exists()).toEqual(true);;
+    expect(wrapper.find('div').exists()).toEqual(true);
   });
 });

--- a/Client/src/Tests/DataCell.test.js
+++ b/Client/src/Tests/DataCell.test.js
@@ -15,7 +15,7 @@ describe('DataCell Component', () => {
 
     it('should render a file input field', () => {
         const wrapper = mount(<DataCell />)
-        expect(wrapper.find('input').exists()).toEqual(true);;
+        expect(wrapper.find('input').exists()).toEqual(true);
     });
 
     it('should render a way to submit the form.', () => {

--- a/Client/src/Tests/Search.test.js
+++ b/Client/src/Tests/Search.test.js
@@ -3,7 +3,6 @@ import renderer from "react-test-renderer";
 import { mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Search from '../Components/Search/Search'
-import TextField from '@material-ui/core';
 configure({ adapter: new Adapter() });
 
 describe('Search Component', () => {

--- a/Server/src/controllers/authenticationController.ts
+++ b/Server/src/controllers/authenticationController.ts
@@ -1,4 +1,4 @@
-import { BadRequest, InternalServerError } from "@tsed/exceptions";
+import { BadRequest } from "@tsed/exceptions";
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationModel } from '../models/AuthenticationModel'

--- a/Server/src/controllers/fileUploadController.ts
+++ b/Server/src/controllers/fileUploadController.ts
@@ -25,7 +25,7 @@ export class fileUploadController {
     }
     else {
       try {
-        this.callFileUploadService(this.filePathOfUpload, response);
+        this.callFileUploadService(this.filePathOfUpload, response).catch(e => console.log("Failed to run callFileUploadService", e));
       } catch (error) {
         console.error(error)
       }

--- a/Server/src/controllers/fileUploadController.ts
+++ b/Server/src/controllers/fileUploadController.ts
@@ -30,7 +30,7 @@ export class fileUploadController {
         console.error(error)
       }
     }
-  };
+  }
 
   private async callFileUploadService(filePath: string, response: Response) {
     let fileService = new fileUploadService(filePath);
@@ -39,7 +39,7 @@ export class fileUploadController {
       response.status(200).json(fileServiceResponse);
     } catch (error) {
       response.status(error.status).json(error.message);
-    };
+    }
   }
 
 }

--- a/Server/src/models/DatasetQueryModel.ts
+++ b/Server/src/models/DatasetQueryModel.ts
@@ -36,7 +36,7 @@ export class DataQueryModel {
         let compositionId = -1; // fallback value if material details were entered
         if (compositionIdRaw[0] != null) {
             compositionId = compositionIdRaw[0].id;
-        };
+        }
 
         let materialDatasetData: IDatasetModel[] = await selectDatasetIdsQuery(this.connection.manager)
             .innerJoin('dataset.materials', 'material')

--- a/Server/src/models/entities/Category.ts
+++ b/Server/src/models/entities/Category.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, EntityManager } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from "typeorm";
 
 
 /**

--- a/Server/src/models/entities/Subcategory.ts
+++ b/Server/src/models/entities/Subcategory.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, EntityManager } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from "typeorm";
 
 
 /**

--- a/Server/src/services/authenticationService.ts
+++ b/Server/src/services/authenticationService.ts
@@ -45,7 +45,7 @@ export class AuthenticationService {
                 await AuthenticationModel.insertSignUpInformation(signUpInformation);
             }
             catch (error) {
-                new InternalServerError("Internal Server Issue. Please try again later", error.message);
+                throw new InternalServerError("Internal Server Issue. Please try again later", error.message);
             }
         }
         this.requestResponse.message = "Success";

--- a/Server/src/tests/models/AuthenticationModel.spec.ts
+++ b/Server/src/tests/models/AuthenticationModel.spec.ts
@@ -1,7 +1,6 @@
-import { createConnection, getConnection, TableForeignKey } from 'typeorm';
+import { createConnection, getConnection } from 'typeorm';
 import { AuthenticationModel } from '../../models/AuthenticationModel';
 import { ISignUpInformation } from '../../genericInterfaces/AuthenticationInterfaces';
-import { ILoginInformation } from '../../genericInterfaces/AuthenticationInterfaces';
 
 
 describe('Authentication Model Methods', () => {

--- a/Server/src/tests/services/authenticationService.spec.ts
+++ b/Server/src/tests/services/authenticationService.spec.ts
@@ -1,5 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
-import { createConnection, getConnection, TableForeignKey } from 'typeorm';
+import { createConnection, getConnection } from 'typeorm';
 import { AuthenticationService } from '../../services/authenticationService'
 
 


### PR DESCRIPTION
This PR addresses all the bugs / code smells that were introduced from Sprint 4 & 5.
Because Authentication was introduced in Sprint 5, there were 13 security hotspots flagged but upon reviewal they were false positives as they were flagged in unit test files. 
Most bugs were also false positives (TypeORM statements which are valid)

A report detailing the debt was written on Confluence -> [Report from Sprint 6 (Sprint 4 to Sprint 5)](https://databoom.atlassian.net/l/c/bzTWLKhf)
I also documented all of this in the Quality Measurements section 10 in the Release doc 2.

Debt before PR:
![image](https://user-images.githubusercontent.com/6520150/105255263-37b4b380-5b51-11eb-8359-90e806853c3d.png)


Debt after PR:
![image](https://user-images.githubusercontent.com/6520150/105255203-223f8980-5b51-11eb-9c18-172a757c1441.png)
