### PR TITLE
flagDataSet route fix

### DIFF
--- a/Server/src/routes/DatasetRouter.ts
+++ b/Server/src/routes/DatasetRouter.ts
@@ -33,7 +33,7 @@ router.delete('/api/v1/dataset/:datasetId', [JWTAuthenticator.verifyJWT, JWTAuth
     dataSetController.createRequestToRejectDataset(request, response)
 })
 
-router.put('/api/v1/flagDataSet/:datasetId', [JWTAuthenticator.verifyJWT, JWTAuthenticator.verifyAdmin], (request: Request, response: Response) => {
+router.put('/api/v1/flagDataSet', [JWTAuthenticator.verifyJWT, JWTAuthenticator.verifyAdmin], (request: Request, response: Response) => {
     dataSetController.createRequestToFlagDataset(request, response)
 })
 


### PR DESCRIPTION
It was noticed just now that there's an issue with the flagDataSet route, where it is set to expect a param when the controller it is attached to is actually expecting a query. This PR fixes that 