### PR TITLE
Bug fix for User Approval of Data Set

### DIFF
--- a/Server/src/controllers/DataSetController.ts
+++ b/Server/src/controllers/DataSetController.ts
@@ -232,7 +232,8 @@ export class DataSetController {
         }
         try {
             this.dataSetService = new DataSetService();
-            let requestResponse = await this.dataSetService.userApprovedDataset(datasetId)
+            let userId: number = request.body.user.account_id
+            let requestResponse = await this.dataSetService.userApprovedDataset(datasetId, userId)
             return response.status(requestResponse.statusCode).json(requestResponse.message);
         } catch (error) {
             response.status(error.status).json(error.message);

--- a/Server/src/migrations/SeedDatabase.ts
+++ b/Server/src/migrations/SeedDatabase.ts
@@ -342,12 +342,12 @@ export class SeedDatabase1611943920000 implements MigrationInterface {
     dataset.subcategoryId = subcategory.id;
     dataset.comments;
     dataset.materials = [];
-    dataset.uploaderId;
+    dataset.uploaderId = 2;
     await connection.manager.save(dataset);
 
     unapproveddataset.datasetId = 8;
     unapproveddataset.flaggedComment;
-    unapproveddataset.isFlagged = 0;
+    unapproveddataset.isFlagged = 1;
     await connection.manager.save(unapproveddataset);
 
     dataset.id = 9;
@@ -411,7 +411,7 @@ export class SeedDatabase1611943920000 implements MigrationInterface {
 
     unapproveddataset.datasetId = 12;
     unapproveddataset.flaggedComment;
-    unapproveddataset.isFlagged = 0;
+    unapproveddataset.isFlagged = 1;
     await connection.manager.save(unapproveddataset);
 
     // Units below this line

--- a/Server/src/models/DatasetModels/DatasetApprovalModel.ts
+++ b/Server/src/models/DatasetModels/DatasetApprovalModel.ts
@@ -63,6 +63,26 @@ export class DatasetApprovalModel {
         return "Dataset Flagged!"
     }
 
+    async verifyUnapprovedDatasetUploader(id: number, userId: number): Promise<any> {
+        let upload = await this.connection.createQueryBuilder(Unapproveddatasets, 'unapproved_datasets')
+            .select('dataset.uploaderId', 'uploaderId')
+            .addSelect('unapproved_datasets.isFlagged', 'isFlagged')
+            .innerJoin(Dataset, 'dataset', 'dataset.id = unapproved_datasets.datasetId')
+            .where('dataset.id = :id', { id: id })
+            .getRawOne();
+        console.log(userId)
+        console.log(upload)
+        if (upload.uploaderId != userId || upload == undefined) {
+            return "User ID does not match uploader ID!"
+        }
+        else if (upload.isFlagged != 1) {
+            return "You cannot approve a data set until it passes initial screening!"
+        }
+        else {
+            return true
+        }
+    }
+
     async approveDataset(datasetId: number) {
         await this.approveSingleDatasetQuery(datasetId)
         await this.commonModel.wipeEntryFromUnapprovedTable(datasetId)

--- a/Server/src/models/DatasetModels/DatasetApprovalModel.ts
+++ b/Server/src/models/DatasetModels/DatasetApprovalModel.ts
@@ -70,8 +70,6 @@ export class DatasetApprovalModel {
             .innerJoin(Dataset, 'dataset', 'dataset.id = unapproved_datasets.datasetId')
             .where('dataset.id = :id', { id: id })
             .getRawOne();
-        console.log(userId)
-        console.log(upload)
         if (upload.uploaderId != userId || upload == undefined) {
             return "User ID does not match uploader ID!"
         }

--- a/Server/src/routes/DatasetRouter.ts
+++ b/Server/src/routes/DatasetRouter.ts
@@ -41,12 +41,12 @@ router.get('/api/v1/userFlaggedDatasets', JWTAuthenticator.verifyJWT, (request: 
     dataSetController.createRequestForUserFlaggedDatasets(request, response)
 })
 
-router.put('/api/v1/adminApprovedDataset/:datasetId', [JWTAuthenticator.verifyJWT, JWTAuthenticator.verifyAdmin], (request: Request, response: Response) => {
-    dataSetController.createAdminApprovedDatasetRequest(request, response)
+router.put('/api/v1/approveDataset/:datasetId', JWTAuthenticator.verifyJWT, (request: Request, response: Response) => {
+    dataSetController.createUserApprovedDatasetRequest(request, response)
 })
 
-router.put('/api/v1/userApprovedDataset/:datasetId', JWTAuthenticator.verifyJWT, (request: Request, response: Response) => {
-    dataSetController.createUserApprovedDatasetRequest(request, response)
+router.put('/api/v1/approveDataset', [JWTAuthenticator.verifyJWT, JWTAuthenticator.verifyAdmin], (request: Request, response: Response) => {
+    dataSetController.createAdminApprovedDatasetRequest(request, response)
 })
 
 export { router as DataSetRouter };

--- a/Server/src/tests/controllers/DatasetController.spec.ts
+++ b/Server/src/tests/controllers/DatasetController.spec.ts
@@ -206,6 +206,55 @@ describe('Data Set Controller ', () => {
         expect(mockResponse.status).toBeCalledWith(200);
     });
 
+    // The two invalid user approval tests must happen before the valid approval tests
+    test('Invalid User Approve Data Set Request; wrong ID', async () => {
+        mockRequest = {
+            body: {
+                user: {
+                    account_id: '2'
+                }
+            },
+            params: {
+                datasetId: 12
+            }
+        }
+        await GetDataControllerController.createUserApprovedDatasetRequest(mockRequest as Request, mockResponse as Response)
+        expect(mockResponse.json).toBeCalledWith("User ID does not match uploader ID!");
+        expect(mockResponse.status).toBeCalledWith(400);
+    });
+
+    test('Invalid User Approve Data Set Request; data set not yet flagged', async () => {
+        mockRequest = {
+            body: {
+                user: {
+                    account_id: '1'
+                }
+            },
+            params: {
+                datasetId: 11
+            }
+        }
+        await GetDataControllerController.createUserApprovedDatasetRequest(mockRequest as Request, mockResponse as Response)
+        expect(mockResponse.json).toBeCalledWith("You cannot approve a data set until it passes initial screening!");
+        expect(mockResponse.status).toBeCalledWith(400);
+    });
+
+    test('Valid User Approve Data Set Request', async () => {
+        mockRequest = {
+            body: {
+                user: {
+                    account_id: '1'
+                }
+            },
+            params: {
+                datasetId: 12
+            }
+        }
+        await GetDataControllerController.createUserApprovedDatasetRequest(mockRequest as Request, mockResponse as Response)
+        expect(mockResponse.json).toBeCalledWith("Successfully approved new data set");
+        expect(mockResponse.status).toBeCalledWith(200);
+    });
+
     test('Valid Admin Approve Data Set Request', async () => {
         mockRequest = {
             query: {
@@ -213,17 +262,6 @@ describe('Data Set Controller ', () => {
             }
         }
         await GetDataControllerController.createAdminApprovedDatasetRequest(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith("Successfully approved new data set");
-        expect(mockResponse.status).toBeCalledWith(200);
-    });
-
-    test('Valid User Approve Data Set Request', async () => {
-        mockRequest = {
-            params: {
-                datasetId: 12
-            }
-        }
-        await GetDataControllerController.createUserApprovedDatasetRequest(mockRequest as Request, mockResponse as Response)
         expect(mockResponse.json).toBeCalledWith("Successfully approved new data set");
         expect(mockResponse.status).toBeCalledWith(200);
     });

--- a/Server/src/tests/services/DataSetService.spec.ts
+++ b/Server/src/tests/services/DataSetService.spec.ts
@@ -306,8 +306,8 @@ describe('data service test', () => {
     done()
   });
 
-  test('User approves a data set, with no additional comments', async done => {
-    let response = await retrieveDataObject.userApprovedDataset(8)
+  test('User approves a data set', async done => {
+    let response = await retrieveDataObject.userApprovedDataset(8, 2)
     expect(response.message).toEqual("Successfully approved new data set");
     expect(response.statusCode).toEqual(200);
     done()


### PR DESCRIPTION
This fixes a bug where when a user inputs a PUT request to approve a data set, they can approve any unapproved data set regardless of if they uploaded this data set originally and/or regardless of whether the data set has passed initial screening (aka. flagged). 

It also fixes issues related to the formatting of the approve data set routes and streamlines them. 