### PR TITLE
No Saved Graphs/Unapproved Data Sets Bug Fix

### DIFF
--- a/Server/src/services/DataSetService.ts
+++ b/Server/src/services/DataSetService.ts
@@ -398,10 +398,7 @@ export class DataSetService {
         try {
             let rawDatasetIds = await this.approvalModel.getUnapprovedDatasets();
             let response: IApprovalDatasetModel[] = [];
-            if (rawDatasetIds.length < 1 || rawDatasetIds == undefined || rawDatasetIds == null) {
-                throw new NotFound("No Unapproved Datasets in database")
-            }
-            else {
+            if (rawDatasetIds.length > 0) {
                 response = await this.compileUnapprovedDatasetArray(rawDatasetIds);
             }
             this.requestResponse.statusCode = 200
@@ -420,11 +417,8 @@ export class DataSetService {
     async getUserFlaggedDatasets(userId: number) {
         try {
             let rawDatasetIds = await this.approvalModel.selectUserFlaggedDatasets(userId);
-            let response: IApprovalDatasetModel[];
-            if (rawDatasetIds.length < 1 || rawDatasetIds == undefined || rawDatasetIds == null) {
-                throw new NotFound("No Flagged Unapproved Datasets in database for this user")
-            }
-            else {
+            let response: IApprovalDatasetModel[] = [];
+            if (rawDatasetIds.length > 0) {
                 response = await this.compileUnapprovedDatasetArray(rawDatasetIds);
             }
             this.requestResponse.statusCode = 200
@@ -444,10 +438,7 @@ export class DataSetService {
         try {
             let rawDatasetIds = await this.approvalModel.selectAllFlaggedDatasets();
             let response: IApprovalDatasetModel[];
-            if (rawDatasetIds.length < 1 || rawDatasetIds == undefined || rawDatasetIds == null) {
-                throw new NotFound("No Flagged Unapproved Datasets in database")
-            }
-            else {
+            if (rawDatasetIds.length > 0) {
                 response = await this.compileUnapprovedDatasetArray(rawDatasetIds);
             }
             this.requestResponse.statusCode = 200

--- a/Server/src/services/GraphsService.ts
+++ b/Server/src/services/GraphsService.ts
@@ -51,11 +51,6 @@ export class GraphsService {
     async fetchUserSavedGraphs(userID: number) {
         try {
             let graphData = await this.dataQuery.fetchSavedGraphs(userID)
-            if (graphData.length == 0) {
-                this.requestResponse.statusCode = 200
-                this.requestResponse.message = "You don't have any saved graphs!"
-                return this.requestResponse
-            }
             this.requestResponse.statusCode = 200
             this.requestResponse.message = graphData as any
             return this.requestResponse

--- a/Server/src/tests/controllers/GraphsController.spec.ts
+++ b/Server/src/tests/controllers/GraphsController.spec.ts
@@ -87,7 +87,7 @@ describe('Graphs State Controller ', () => {
   });
 
   test('Valid User Saved Graphs Request; user has no graphs', async () => {
-    let expectedResponse = "You don't have any saved graphs!"
+    let expectedResponse = []
     mockRequest = {
       body: {
         user: {

--- a/Server/src/tests/services/DataSetService.spec.ts
+++ b/Server/src/tests/services/DataSetService.spec.ts
@@ -258,10 +258,11 @@ describe('data service test', () => {
     done()
   });
 
-  test('Asks for all flagged data sets of non-existant user, expects an error', async () => {
-    await expect(retrieveDataObject.getUserFlaggedDatasets(0))
-      .rejects
-      .toThrow("No Flagged Unapproved Datasets in database for this user");
+  test('Asks for all flagged data sets of non-existant user, expects an error', async done => {
+    let response = await retrieveDataObject.getUserFlaggedDatasets(0)
+    expect(response.message).toEqual([]);
+    expect(response.statusCode).toEqual(200);
+    done()
   });
 
   test('Flag an unapproved data set, with no additional comments', async done => {


### PR DESCRIPTION
This PR fixes a bug where if a user has no saved graphs and/or unapproved data sets that the profile page loads an error