### PR TITLE
Update User Favorite/Uploaded Data Set Requests

### DIFF
--- a/Server/src/controllers/DataSetController.ts
+++ b/Server/src/controllers/DataSetController.ts
@@ -53,17 +53,17 @@ export class DataSetController {
         let userId: any = request.body.user.account_id
         try {
             this.dataSetService = new DataSetService();
-            let arrayOfData = await this.dataSetService.getUserUploadedDatasets(userId)
-            return response.status(200).json(arrayOfData);
+            let requestResponse = await this.dataSetService.getUserUploadedDatasets(userId)
+            return response.status(requestResponse.statusCode).json(requestResponse.message);
         } catch (err) {
             response.status(500).json(err);
         }
     }
 
     /**
-     * This controller will take a request, grab the user ID, and if it a real number will then process the request,
-     * send it to the getDataService to acquire an array of data sets that were saved by this user ID, and
-     * then return a response with the array of data sets. If the request is invalid, or some other problem arrises, 
+     * This controller will take a request, grab the user ID, send it to the service
+     * to acquire an array of data sets that were saved by this user ID, and then return a response with 
+     * the array of data sets. If the request is invalid, or some other problem arrises, 
      * it will throw an error.
      * 
      * @param request
@@ -75,40 +75,39 @@ export class DataSetController {
         let userId: any = request.body.user.account_id
         try {
             this.dataSetService = new DataSetService();
-            let arrayOfData = await this.dataSetService.getUserFavoriteDatasets(userId)
-            return response.status(200).json(arrayOfData);
+            let requestResponse = await this.dataSetService.getUserFavoriteDatasets(userId)
+            return response.status(requestResponse.statusCode).json(requestResponse.message);
         } catch (err) {
             response.status(500).json(err);
         }
     }
 
-    //TODO: Readd later
     /**
-     * This controller will take a request, grab the user email and data set ID, verify said ID is a number,
-     * and then send the service a request to add the user's saved data set preference to the database.
+     * This controller will take a request, grab the user ID and data set ID, verify data set ID is a number,
+     * and then send the service a request to add this favorite data set to the database.
      * 
      * @param request
      * An object containing the request information and parameters: Request 
      * @param response 
      * An object containing a response: Response
-    async createRequestForAddingSavedDataset(request: Request, response: Response) {
-        let userEmail = request.params.userEmail;
+     */
+    async createRequestToAddUserFavoriteDataSet(request: Request, response: Response) {
         let requestParam = request.params.datasetId;
-        let datasetId: number = +requestParam;
+        let datasetId = Number(requestParam);
         if (isNaN(datasetId)) {
             response.status(400).json("Invalid data set ID entered");
         }
         else {
+            let userId: number = request.body.user.account_id
             try {
-                let executionStatus = await this.dataSetService.addSavedDatasetService(userEmail, datasetId)
-                if (executionStatus[0]) { return response.status(200).json(executionStatus[1]); }
-                else { return response.status(400).json(executionStatus[1]); }
+                this.dataSetService = new DataSetService();
+                let requestResponse = await this.dataSetService.addUserFavoriteDataset(userId, datasetId)
+                return response.status(requestResponse.statusCode).json(requestResponse.message);
             } catch (err) {
-                response.status(500).json(err);
+                response.status(err.status).json(err.message);
             }
         }
     }
-     */
 
     async createRequestToDeleteUserFavoriteDataSet(request: Request, response: Response) {
         let requestParam = request.params.datasetId;

--- a/Server/src/models/DatasetModels/DatasetQueryModel.ts
+++ b/Server/src/models/DatasetModels/DatasetQueryModel.ts
@@ -198,7 +198,7 @@ export class DataQueryModel {
      */
     async removeUserFavoriteDatasetModel(userId: number, datasetId: number) {
         await this.connection.query("DELETE FROM accounts_datasets_dataset WHERE accountsId = ? AND datasetId = ?", [userId, datasetId]);
-        return "User favorite successfully removed";
+        return "User favorite data set successfully removed";
     }
 
     /**

--- a/Server/src/routes/DatasetRouter.ts
+++ b/Server/src/routes/DatasetRouter.ts
@@ -11,17 +11,24 @@ import { JWTAuthenticator } from '../middleware/JWTAuthenticator';
 let router = Router();
 let dataSetController = new DataSetController();
 
-//Note to Self: Verify which of these routes are protected 
-// JWTAuthenticator.verifyJWT, JWTAuthenticator.verifyAdmin
-router.get('/api/v1/dataset/userUploadedDatasets/:userUploadedDatasets', (request: Request, response: Response) => {
+router.get('/api/v1/uploadedDatasets', JWTAuthenticator.verifyJWT, (request: Request, response: Response) => {
     dataSetController.createRequestForUserUploadedDatasets(request, response);
 });
 
-router.get('/api/v1/dataset/userSavedDatsets/:userSavedDatsets', (request: Request, response: Response) => {
+router.get('/api/v1/favoriteDatasets', JWTAuthenticator.verifyJWT, (request: Request, response: Response) => {
     dataSetController.createRequestForUserFavoriteDatsets(request, response);
 });
 
-router.get('/api/v1/dataset/fetchUnapprovedDatasets$', (request: Request, response: Response) => {
+router.post('/api/v1/favoriteDatasets/:datasetId', JWTAuthenticator.verifyJWT, (request: Request, response: Response) => {
+    dataSetController.createRequestToAddUserFavoriteDataSet(request, response);
+});
+
+router.delete('/api/v1/favoriteDatasets/:datasetId', JWTAuthenticator.verifyJWT, (request: Request, response: Response) => {
+    dataSetController.createRequestToDeleteUserFavoriteDataSet(request, response);
+});
+
+//TODO: Rename route name to /api/v1/unapprovedDatasets to bring it in line with current standard
+router.get('/api/v1/dataset/fetchUnapprovedDatasets$', [JWTAuthenticator.verifyJWT, JWTAuthenticator.verifyAdmin], (request: Request, response: Response) => {
     dataSetController.createRequestForUnapprovedDatsets(request, response);
 });
 

--- a/Server/src/services/DataSetService.ts
+++ b/Server/src/services/DataSetService.ts
@@ -282,14 +282,20 @@ export class DataSetService {
      * @param userReceived
      * Account ID: number
      */
-    async getUserUploadedDatasets(userReceived: string) {
-        let rawData = await this.dataQuery.getUploadedDatasetIDOfUser(userReceived);
-        if (rawData[0]) {
-            let setOfData = await this.getDatasetsFromRawData(rawData[1]);
-            return [true, setOfData];
-        }
-        else {
-            return rawData;
+    async getUserUploadedDatasets(userReceived: number) {
+        try {
+            let rawData = await this.dataQuery.getUploadedDatasetIDOfUser(userReceived);
+            if (rawData) {
+                let setOfData = await this.getDatasetsFromRawData(rawData);
+                this.requestResponse.message = setOfData as any
+            }
+            else {
+                this.requestResponse.message = [] as any
+            }
+            this.requestResponse.statusCode = 200
+            return this.requestResponse
+        } catch (error) {
+            throw new Error("Something went wrong getting all uploaded data sets. Try later")
         }
     }
 
@@ -302,36 +308,48 @@ export class DataSetService {
      * Account ID: number
      */
     async getUserFavoriteDatasets(userReceived: number) {
-        let rawData = await this.dataQuery.getFavoriteDatasetIDOfUser(userReceived);
-        if (rawData[0]) {
-            let setOfData = await this.getDatasetsFromRawData(rawData[1]);
-            return [true, setOfData];
-        }
-        else {
-            return rawData;
+        try {
+            let rawData = await this.dataQuery.getFavoriteDatasetIDOfUser(userReceived);
+            if (rawData) {
+                let setOfData = await this.getDatasetsFromRawData(rawData);
+                this.requestResponse.message = setOfData as any
+            }
+            else {
+                this.requestResponse.message = [] as any
+            }
+            this.requestResponse.statusCode = 200
+            return this.requestResponse
+        } catch (error) {
+            throw new Error("Something went wrong getting all favorite data sets. Try later")
         }
     }
 
     /**
-     * This method is used to add a saved data set of a user. It will take a user's email and a data set ID
+     * This method is used to add a saved data set of a user. It will take a user's ID and a data set ID
      * and send this to the service for input.
      * 
-     * @param userEmail
-     * User's Email: string
+     * @param userId
+     * User's ID: number
      * @param datasetId
      * Data Set ID: number
      */
-    async addUserFavoriteDataset(userEmail: string, datasetId: number) {
-        let executionStatus = await this.dataQuery.addUserFavoriteDatasetModel(userEmail, datasetId);
-        return executionStatus;
+    async addUserFavoriteDataset(userId: number, datasetId: number) {
+        try {
+            let response = await this.dataQuery.addUserFavoriteDatasetModel(userId, datasetId);
+            this.requestResponse.statusCode = 200
+            this.requestResponse.message = response as any
+            return this.requestResponse
+        } catch (error) {
+            throw new Error("Something went wrong adding a favorite data set. Try later")
+        }
     }
 
     /**
      * This method is used to remove a saved data set from the user's favorites. It will take a user's email 
      * and a data set ID and send this to the service for input.
      * 
-     * @param userEmail
-     * User's Email: string
+     * @param userId
+     * User's ID: number
      * @param datasetId
      * Data Set ID: number
      */
@@ -342,7 +360,7 @@ export class DataSetService {
             this.requestResponse.message = response as any
             return this.requestResponse
         } catch (error) {
-            throw new Error("Something went wrong fetching all Unapproved Datasets. Try later")
+            throw new Error("Something went wrong removing a favorite data set. Try later")
         }
     }
 

--- a/Server/src/tests/controllers/DatasetController.spec.ts
+++ b/Server/src/tests/controllers/DatasetController.spec.ts
@@ -143,7 +143,7 @@ describe('Data Set Controller ', () => {
             }
         }
         await GetDataControllerController.createRequestToDeleteUserFavoriteDataSet(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith("User favorite successfully removed");
+        expect(mockResponse.json).toBeCalledWith("User favorite data set successfully removed");
         expect(mockResponse.status).toBeCalledWith(200);
     });
 
@@ -159,7 +159,7 @@ describe('Data Set Controller ', () => {
             }
         }
         await GetDataControllerController.createRequestToDeleteUserFavoriteDataSet(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith("User favorite successfully removed");
+        expect(mockResponse.json).toBeCalledWith("User favorite data set successfully removed");
         expect(mockResponse.status).toBeCalledWith(200);
     });
 

--- a/Server/src/tests/controllers/DatasetController.spec.ts
+++ b/Server/src/tests/controllers/DatasetController.spec.ts
@@ -56,66 +56,64 @@ describe('Data Set Controller ', () => {
         done()
     });
 
-    //TODO: Readd later
-    /**
-    test('Valid Save Data Set Request', async () => {
+    test('Valid Add Favorite Data Set Request', async () => {
         mockRequest = {
+            body: {
+                user: {
+                    account_id: '4'
+                }
+            },
             params: {
                 datasetId: '1'
             }
         }
-        await GetDataControllerController.createRequestForAddingSavedDataset(mockRequest as Request, mockResponse as Response)
+        await GetDataControllerController.createRequestToAddUserFavoriteDataSet(mockRequest as Request, mockResponse as Response)
         expect(mockResponse.json).toBeCalledWith("Favorite data set successfully saved");
         expect(mockResponse.status).toBeCalledWith(200);
     });
 
-    test('Save Data Set Request, Data Set Already Saved', async () => {
+    test('Add Favorite Data Set Request, Data Set Already Saved', async () => {
         mockRequest = {
+            body: {
+                user: {
+                    account_id: '1'
+                }
+            },
             params: {
-                userEmail: 'j.comkj',
                 datasetId: '2'
             }
         }
-        await GetDataControllerController.createRequestForAddingSavedDataset(mockRequest as Request, mockResponse as Response)
+        await GetDataControllerController.createRequestToAddUserFavoriteDataSet(mockRequest as Request, mockResponse as Response)
         expect(mockResponse.json).toBeCalledWith("Favorite data set is already saved");
         expect(mockResponse.status).toBeCalledWith(200);
     });
 
-    test('Invalid Save Data Set Request', async () => {
+    test('Invalid Add Favorite Data Set Request', async () => {
         mockRequest = {
+            body: {
+                user: {
+                    account_id: '1'
+                }
+            },
             params: {
-                userEmail: 'fake@email.com',
-                datasetId: '1'
-            }
-        }
-        await GetDataControllerController.createRequestForAddingSavedDataset(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith("Invalid user email provided");
-        expect(mockResponse.status).toBeCalledWith(400);
-    });
-
-    test('Invalid Save Data Set Request', async () => {
-        mockRequest = {
-            params: {
-                userEmail: 'j.comkj',
                 datasetId: "wrtrterterte"
             }
         }
-        await GetDataControllerController.createRequestForAddingSavedDataset(mockRequest as Request, mockResponse as Response)
+        await GetDataControllerController.createRequestToAddUserFavoriteDataSet(mockRequest as Request, mockResponse as Response)
         expect(mockResponse.json).toBeCalledWith("Invalid data set ID entered");
         expect(mockResponse.status).toBeCalledWith(400);
     });
-    */
 
     test('Valid Get User Uploaded Data Sets Request', async () => {
         mockRequest = {
             body: {
                 user: {
-                    account_id: 'tester@123.com'
+                    account_id: '3'
                 }
             }
         }
         await GetDataControllerController.createRequestForUserUploadedDatasets(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith([true, oneFavoriteDataset]);
+        expect(mockResponse.json).toBeCalledWith(oneFavoriteDataset);
         expect(mockResponse.status).toBeCalledWith(200);
     });
 
@@ -128,7 +126,7 @@ describe('Data Set Controller ', () => {
             }
         }
         await GetDataControllerController.createRequestForUserFavoriteDatsets(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith([true, oneFavoriteDataset]);
+        expect(mockResponse.json).toBeCalledWith(oneFavoriteDataset);
         expect(mockResponse.status).toBeCalledWith(200);
     });
 

--- a/Server/src/tests/models/DatasetQueryModel.spec.ts
+++ b/Server/src/tests/models/DatasetQueryModel.spec.ts
@@ -1,7 +1,7 @@
 import { createConnection, getConnection } from 'typeorm';
 import { DataQueryModel } from '../../models/DatasetModels/DatasetQueryModel';
 
-describe('data service test', () => {
+describe('data query model test', () => {
     let dataQueryModel: DataQueryModel;
     jest.setTimeout(60000)
 
@@ -75,33 +75,27 @@ describe('data service test', () => {
     });
 
     test('Feeds the email of account ID of 1 and expects to see a data set ID of 1 returned', async done => {
-        let arrayOfData = await dataQueryModel.getUploadedDatasetIDOfUser("j.comkj")
-        expect(arrayOfData[1][0].dataset_id).toEqual(1);
+        let arrayOfData = await dataQueryModel.getUploadedDatasetIDOfUser(1)
+        expect(arrayOfData[0].dataset_id).toEqual(1);
         done()
     });
 
     test('Feeds an account ID of 1 and expects to see a data set IDs of 2 returned', async done => {
         let arrayOfData = await dataQueryModel.getFavoriteDatasetIDOfUser(1)
-        expect(arrayOfData[1][0].dataset_id).toEqual(2);
+        expect(arrayOfData[0].dataset_id).toEqual(2);
         done()
     });
 
-    test('Feeds an invalid email to uploads of user request and expects to see an error message', async done => {
-        let arrayOfData = await dataQueryModel.getUploadedDatasetIDOfUser("not valid")
-        expect(arrayOfData[1]).toEqual("Invalid user email provided");
+    test('Feeds an invalid account ID and expects to see an empty return', async done => {
+        let arrayOfData = await dataQueryModel.getFavoriteDatasetIDOfUser(-1)
+        expect(arrayOfData).toEqual([]);
         done()
     });
 
-    test('Feeds an invalid account ID and expects to see an no IDs returned', async done => {
-        let arrayOfData = await dataQueryModel.getFavoriteDatasetIDOfUser(5000)
-        expect(arrayOfData[0].dataset_id).toBeUndefined()
-        done()
+    test('Attempts to add favorite data set to non existant user', async () => {
+        await expect(dataQueryModel.addUserFavoriteDatasetModel(-1, 3))
+            .rejects
+            .toThrow("Something went wrong adding a favorite data set. Try later");
     });
 
-    test('Attempts to add favorite data set to non existant user', async done => {
-        let arrayOfData = await dataQueryModel.addUserFavoriteDatasetModel("not valid", 3)
-        expect(arrayOfData[0]).toEqual(false);
-        expect(arrayOfData[1]).toEqual("Invalid user email provided");
-        done()
-    });
 })

--- a/Server/src/tests/services/DataSetService.spec.ts
+++ b/Server/src/tests/services/DataSetService.spec.ts
@@ -231,7 +231,7 @@ describe('data set service test', () => {
 
   test('Removes data set with ID 5 as a favorite of account ID 1', async done => {
     let response = await retrieveDataObject.removeUserFavoriteDataset(1, 5)
-    expect(response.message).toEqual("User favorite successfully removed")
+    expect(response.message).toEqual("User favorite data set successfully removed")
     done()
   });
 

--- a/Server/src/tests/services/DataSetService.spec.ts
+++ b/Server/src/tests/services/DataSetService.spec.ts
@@ -3,10 +3,9 @@ import { IDataRequestModel } from "../../models/interfaces/DataRequestModelInter
 
 import { createConnection, getConnection } from 'typeorm';
 import { IApprovalDatasetModel } from "../../models/interfaces/DatasetModelInterface";
-import { BadRequest, NotFound } from "@tsed/exceptions";
 
 
-describe('data service test', () => {
+describe('data set service test', () => {
   let retrieveDataObject: DataSetService;
   jest.setTimeout(60000)
 
@@ -192,39 +191,41 @@ describe('data service test', () => {
     done()
   });
 
-  test('Feeds the email of account ID of 3 and expects to see an uploaded data set with ID of 2 returned', async done => {
-    let arrayOfData = await retrieveDataObject.getUserUploadedDatasets("tester@123.com")
-    expect(arrayOfData[1][0].dataset_id).toEqual(2);
+  test('Feeds account ID of 3 and expects to see an uploaded data set with ID of 2 returned', async done => {
+    let response = await retrieveDataObject.getUserUploadedDatasets(3)
+    let arrayOfData = response.message as unknown as IApprovalDatasetModel[]
+    expect(arrayOfData[0].dataset_id).toEqual(2);
     done()
   });
 
   test('Feeds an account ID of 1 and expects to see a favorited data set IDs of 2 returned', async done => {
-    let arrayOfData = await retrieveDataObject.getUserFavoriteDatasets(1)
-    expect(arrayOfData[1][0].dataset_id).toEqual(2);
+    let response = await retrieveDataObject.getUserFavoriteDatasets(1)
+    let arrayOfData = response.message as unknown as IApprovalDatasetModel[]
+    expect(arrayOfData[0].dataset_id).toEqual(2);
     done()
   });
 
   test('Feeds an invalid email and expects to see an error message', async done => {
-    let arrayOfData = await retrieveDataObject.getUserUploadedDatasets("nothing")
-    expect(arrayOfData[1]).toEqual("Invalid user email provided");
+    let response = await retrieveDataObject.getUserUploadedDatasets(-1)
+    expect(response.message).toEqual([])
     done()
   });
 
-  test('Feeds an invalid account and expects to see an error message', async done => {
-    let arrayOfData = await retrieveDataObject.getUserFavoriteDatasets(-1)
-    expect(arrayOfData[0].dataset_id).toBeUndefined()
+  test('Feeds an invalid account and expects to see an empty return', async done => {
+    let response = await retrieveDataObject.getUserFavoriteDatasets(-1)
+    expect(response.message).toEqual([])
     done()
   });
 
   test('Sets data set with ID 5 as a favorite of account ID 1', async done => {
-    let response = await retrieveDataObject.addUserFavoriteDataset("j.comkj", 5)
-    expect(response[1]).toEqual("Favorite data set successfully saved")
+    let response = await retrieveDataObject.addUserFavoriteDataset(1, 5)
+    expect(response.message).toEqual("Favorite data set successfully saved")
     done()
   });
 
   test('Sets data set with ID 5 as a favorite of account ID 1 a second time', async done => {
-    let response = await retrieveDataObject.addUserFavoriteDataset("j.comkj", 5)
-    expect(response[1]).toEqual("Favorite data set is already saved")
+    let response = await retrieveDataObject.addUserFavoriteDataset(1, 5)
+    expect(response.message).toEqual("Favorite data set is already saved")
     done()
   });
 


### PR DESCRIPTION
This PR updates the routes and methods of user favorite/uploaded data set requests to the current standard and ensures full functionality. A number of fixes were needed, such as the route/controller for adding a user favorite data set, which was accidently removed at some point. 