### PR TITLE
[#298] Frontend/graph optimization

### DIFF
--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -6,11 +6,14 @@ import React, { useEffect, useRef } from 'react'
 import { Box } from "@material-ui/core"
 import { IAxisStateModel } from "../../Models/Graph/IGraphStateModel"
 import { IGraphDatasetModel } from "../../Models/Graph/IGraphDatasetModel"
+import am4themes_material from "@amcharts/amcharts4/themes/animated"
 
 interface IProps {
   datasets: IGraphDatasetModel[],
   axes: IAxisStateModel[]
 }
+
+am4core.useTheme(am4themes_material)
 
 const getSeriesName = (dataset: IGraphDatasetModel) => {
   return `${dataset.id}`
@@ -46,7 +49,8 @@ export default function Graph(props: IProps) {
         datasetSeries = setUpSeries(chartRef.current, dataset)
       }
 
-      if (!datasetSeries.data || datasetSeries.data) {
+      //optimization to only set data if it wasnt set before
+      if (!datasetSeries.data || datasetSeries.data.length == 0) {
         datasetSeries.data = dataset.points
       }
 
@@ -67,11 +71,11 @@ export default function Graph(props: IProps) {
   }
 
   const shouldHideDataset = (datasetSeries: am4charts.Series, dataset: IGraphDatasetModel) => {
-    return dataset.isHidden && !datasetSeries.isHidden
+    return dataset.isHidden && (!datasetSeries.isHidden || !datasetSeries.isHiding)
   }
 
   const shouldShowDataset = (datasetSeries: am4charts.Series, dataset: IGraphDatasetModel) => {
-    return !dataset.isHidden && datasetSeries.isHidden
+    return !dataset.isHidden && (datasetSeries.isHidden || datasetSeries.isHiding)
   }
 
   const pullRemovedDatasets = (chart: am4charts.XYChart) => {
@@ -82,8 +86,8 @@ export default function Graph(props: IProps) {
     })
   }
 
-  const setUpSeries = (chart: am4charts.XYChart, dataset: IGraphDatasetModel): am4charts.ColumnSeries => {
-    const datasetSeries = chart.series.push(new am4charts.ColumnSeries())
+  const setUpSeries = (chart: am4charts.XYChart, dataset: IGraphDatasetModel): am4charts.XYSeries => {
+    const datasetSeries = chart.series.push(new am4charts.XYSeries())
     const bullet = datasetSeries.bullets.push(new am4core.Circle())
     bullet.radius = 5
     bullet.tooltipText = `${dataset.name}
@@ -94,7 +98,6 @@ export default function Graph(props: IProps) {
     datasetSeries.dataFields.valueY = `y`
     datasetSeries.name = getSeriesName(dataset)
     datasetSeries.data = []
-    datasetSeries.minBulletDistance = 20
     return datasetSeries
   }
 

--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -1,7 +1,7 @@
 import * as am4charts from "@amcharts/amcharts4/charts"
 import * as am4core from "@amcharts/amcharts4/core"
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import { Box } from "@material-ui/core"
 import { IAxisStateModel } from "../../Models/Graph/IGraphStateModel"
@@ -15,22 +15,45 @@ interface IProps {
 
 am4core.useTheme(am4themes_material)
 
+const getSeriesName = (dataset: IGraphDatasetModel) => {
+  return `${dataset.id}`
+}
+
 export default function Graph(props: IProps) {
   const { datasets, axes } = { ...props }
+  const chartRef = useRef<am4charts.XYChart>()
 
-  useEffect(() => setUpGraph(), [datasets])
+  useEffect(() => initiateGraph(), [])
+  useEffect(() => chartRef.current && syncGraphData(), [datasets])
 
-  const addSeries = (chart) => {
+  const syncGraphData = () => {
+    const xAxis = chartRef.current.xAxes.getIndex(0)
+    const yAxis = chartRef.current.yAxes.getIndex(0)
+    console.log(chartRef.current.xAxes, 'undef')
+    updateAxis(xAxis, yAxis)
+    addSeries(chartRef.current)
+    console.log(chartRef.current.series, 'series')
+  }
+
+  const addSeries = (chart: am4charts.XYChart) => {
+    console.log("🚀 ~ file: Graph.tsx ~ line 40 ~ addSeries ~ datasets", datasets)
     datasets.forEach(dataset => {
-      const lineSeries = chart.series.push(new am4charts.CandlestickSeries())
-      const bullet = lineSeries.bullets.push(new am4charts.CircleBullet())
-      //todo make tooltip nice
-      bullet.tooltipText = `${dataset.name}
-      ${axes[0].variableName}: {${dataset.id}x} ${axes[0].units}
-      ${axes[1].variableName}: {${dataset.id}y} ${axes[1].units}`
+      const datasetSeriesIndex = chart.series.values.findIndex(series => series.name == getSeriesName(dataset))
+      //ensures that a series was only added once to optimize perfomance
+      if (datasetSeriesIndex === -1) {
+        const lineSeries = chart.series.push(new am4charts.CandlestickSeries())
+        const bullet = lineSeries.bullets.push(new am4charts.CircleBullet())
+        //todo make tooltip nice
+        bullet.tooltipText = `${dataset.name}
+        ${axes[0].variableName}: {${dataset.id}x} ${axes[0].units}
+        ${axes[1].variableName}: {${dataset.id}y} ${axes[1].units}`
 
-      lineSeries.dataFields.valueX = `${dataset.id}x`
-      lineSeries.dataFields.valueY = `${dataset.id}y`
+        lineSeries.dataFields.valueX = `${dataset.id}x`
+        lineSeries.dataFields.valueY = `${dataset.id}y`
+        lineSeries.name = getSeriesName(dataset)
+        lineSeries.data = []
+        mergeDatasetPoints(dataset, lineSeries.data)
+      }
     })
   }
 
@@ -49,16 +72,18 @@ export default function Graph(props: IProps) {
       return
     }
     //for all current dataset points:
+    console.log(dataset.points, 'dataset.points')
     for (let pointIndex = 0; pointIndex < dataset.points.length; pointIndex++) {
       //create new point that has previous points info and this one's
       const mergedPoint = { ...data[pointIndex], [`${dataset.id}x`]: dataset.points[pointIndex].x, [`${dataset.id}y`]: dataset.points[pointIndex].y }
+      console.log(mergedPoint, 'mergedPoint')
       data[pointIndex] = mergedPoint
     }
+    console.log(data, 'data')
   }
 
   const subscribeToChartEvents = (chart: am4charts.XYChart, xAxis: am4charts.Axis, yAxis: am4charts.Axis) => {
     chart.events.on("ready", function () {
-      //todo zoom to values or indeces?
       axes[0].zoomStartIndex &&
         axes[0].zoomEndIndex &&
         xAxis.zoomToIndexes(axes[0].zoomStartIndex, axes[0].zoomEndIndex)
@@ -78,21 +103,18 @@ export default function Graph(props: IProps) {
     yAxis.title.text = `${axes[1].variableName}, ${axes[1].units}`
   }
 
-  const setUpGraph = () => {
-    const chart = am4core.create("chartdiv", am4charts.XYChart)
-    chart.data = buildDataForGraph(datasets)
+  const initiateGraph = () => {
+    chartRef.current = am4core.create("chartdiv", am4charts.XYChart)
 
-    const xAxis = chart.xAxes.push(new am4charts.ValueAxis())
-    const yAxis = chart.yAxes.push(new am4charts.ValueAxis())
-    updateAxis(xAxis, yAxis)
-    addSeries(chart)
+    chartRef.current.scrollbarX = new am4core.Scrollbar()
+    chartRef.current.scrollbarY = new am4core.Scrollbar()
+    chartRef.current.cursor = new am4charts.XYCursor()
+    chartRef.current.exporting.menu = new am4core.ExportMenu()
 
-    chart.scrollbarX = new am4core.Scrollbar()
-    chart.scrollbarY = new am4core.Scrollbar()
-    chart.cursor = new am4charts.XYCursor()
-    chart.exporting.menu = new am4core.ExportMenu()
-
-    subscribeToChartEvents(chart, xAxis, yAxis)
+    const xAxis = chartRef.current.xAxes.push(new am4charts.ValueAxis())
+    const yAxis = chartRef.current.yAxes.push(new am4charts.ValueAxis())
+    subscribeToChartEvents(chartRef.current, xAxis, yAxis)
+    chartRef.current = chartRef.current
   }
 
   return (

--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -23,7 +23,6 @@ export default function Graph(props: IProps) {
   const { datasets, axes } = { ...props }
   const chartRef = useRef<am4charts.XYChart>()
 
-  //todo order is important? (code should be order agnostic)
   useEffect(() => initiateGraph(), [])
   useEffect(() => chartRef.current && handleUnitsUpdated(), [axes[0].units, axes[1].units])
   useEffect(() => chartRef.current && handleDatasetsUpdated(), [datasets])
@@ -130,6 +129,7 @@ export default function Graph(props: IProps) {
     chartRef.current.scrollbarX = new am4core.Scrollbar()
     chartRef.current.scrollbarY = new am4core.Scrollbar()
     chartRef.current.cursor = new am4charts.XYCursor()
+    chartRef.current.cursor.behavior = "zoomXY"
     chartRef.current.exporting.menu = new am4core.ExportMenu()
 
     const xAxis = chartRef.current.xAxes.push(new am4charts.ValueAxis())

--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -39,7 +39,6 @@ export default function Graph(props: IProps) {
   }
 
   const pushAddedUpdatedDatasets = (chart: am4charts.XYChart) => {
-    console.log("🚀 ~ file: Graph.tsx ~ line 43 ~ pushAddedUpdatedDatasets ~ datasets", datasets)
     datasets.forEach(dataset => {
       let datasetSeries = chart.series.values.find(series => series.name == getSeriesName(dataset))
 
@@ -51,8 +50,28 @@ export default function Graph(props: IProps) {
         datasetSeries.data = dataset.points
       }
 
-      datasetSeries.visible = !dataset.isHidden
+      toggleVisibilityIfNeed(datasetSeries, dataset)
     })
+  }
+
+  const toggleVisibilityIfNeed = (datasetSeries: am4charts.Series, dataset: IGraphDatasetModel) => {
+    if (shouldHideDataset(datasetSeries, dataset)) {
+      datasetSeries.hide()
+      return
+    }
+
+    if (shouldShowDataset(datasetSeries, dataset)) {
+      datasetSeries.show()
+      return
+    }
+  }
+
+  const shouldHideDataset = (datasetSeries: am4charts.Series, dataset: IGraphDatasetModel) => {
+    return dataset.isHidden && !datasetSeries.isHidden
+  }
+
+  const shouldShowDataset = (datasetSeries: am4charts.Series, dataset: IGraphDatasetModel) => {
+    return !dataset.isHidden && datasetSeries.isHidden
   }
 
   const pullRemovedDatasets = (chart: am4charts.XYChart) => {
@@ -63,10 +82,10 @@ export default function Graph(props: IProps) {
     })
   }
 
-  const setUpSeries = (chart: am4charts.XYChart, dataset: IGraphDatasetModel): am4charts.CandlestickSeries => {
-    const datasetSeries = chart.series.push(new am4charts.CandlestickSeries())
-    const bullet = datasetSeries.bullets.push(new am4charts.CircleBullet())
-
+  const setUpSeries = (chart: am4charts.XYChart, dataset: IGraphDatasetModel): am4charts.ColumnSeries => {
+    const datasetSeries = chart.series.push(new am4charts.ColumnSeries())
+    const bullet = datasetSeries.bullets.push(new am4core.Circle())
+    bullet.radius = 5
     bullet.tooltipText = `${dataset.name}
         ${axes[0].variableName}: {x} ${axes[0].units}
         ${axes[1].variableName}: {y} ${axes[1].units}`
@@ -75,6 +94,7 @@ export default function Graph(props: IProps) {
     datasetSeries.dataFields.valueY = `y`
     datasetSeries.name = getSeriesName(dataset)
     datasetSeries.data = []
+    datasetSeries.minBulletDistance = 20
     return datasetSeries
   }
 

--- a/Client/src/Components/Graph/GraphView.tsx
+++ b/Client/src/Components/Graph/GraphView.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Typography } from "@material-ui/core"
+import { Box, Grid } from "@material-ui/core"
 import { IGraphStateModel, newGraphState } from "../../Models/Graph/IGraphStateModel"
 import React, { useState } from "react"
 
@@ -6,7 +6,6 @@ import Graph from './Graph'
 import { GraphStateControl } from "./GraphControls/GraphStateControl"
 import { IDatasetModel } from "../../Models/Datasets/IDatasetModel"
 import { IGraphDatasetModel } from '../../Models/Graph/IGraphDatasetModel'
-import { Link } from "react-router-dom"
 import { getGraphDatasets } from "./GraphFunctions"
 import { useParams } from "react-router"
 
@@ -28,11 +27,6 @@ export default function GraphView() {
 
   return (
     <>
-      <Link to={'/uploadDataset/' + 2} >
-        <Typography>
-          Hello
-        </Typography>
-      </Link>
       <Box ml={8}>
         <Grid container spacing={3}>
           <Grid item container sm={7} >


### PR DESCRIPTION
This PR makes the graph smooth as butter, hiding/unhiding a dataset is super fast, removing datasets is as well. Default cursor behaviour was changed to zoom on both axes, also the zoom doesnt reset when hiding/removing the dataset. Optimized graph data calculation by creating a series per dataset, this also removed a need to map datasets points to understandable to graph