### PR TITLE
Added Indication when Adding Exising Permissions

### DIFF
--- a/Server/src/models/entities/Accounts.ts
+++ b/Server/src/models/entities/Accounts.ts
@@ -55,5 +55,6 @@ export class Accounts {
 export const selectAccountIdFromEmailQuery = (connection: Connection, email: string) =>
     connection.createQueryBuilder(Accounts, 'account')
         .select('account.id', 'id')
+        .addSelect('account.admin', 'permissionLevel')
         .where('account.email = :email', { email: email })
         .getRawOne();

--- a/Server/src/services/AdminManagementService.ts
+++ b/Server/src/services/AdminManagementService.ts
@@ -1,4 +1,4 @@
-import { NotFound } from "@tsed/exceptions";
+import { BadRequest, NotFound } from "@tsed/exceptions";
 import { IResponse } from '../genericInterfaces/ResponsesInterface';
 import { AdminManagementModel } from "../models/AdminManagementModel";
 
@@ -31,6 +31,9 @@ export class AdminManagementService {
             if (error instanceof NotFound) {
                 throw new NotFound(error.message)
             }
+            else if (error instanceof BadRequest) {
+                throw new BadRequest(error.message)
+            }
             else {
                 throw new Error("Something went wrong when adding admin permissions. Try again later")
             }
@@ -46,6 +49,9 @@ export class AdminManagementService {
         } catch (error) {
             if (error instanceof NotFound) {
                 throw new NotFound(error.message)
+            }
+            else if (error instanceof BadRequest) {
+                throw new BadRequest(error.message)
             }
             else {
                 throw new Error("Something went wrong removing admin permissions. Try again later")

--- a/Server/src/tests/controllers/AdminManagementController.spec.ts
+++ b/Server/src/tests/controllers/AdminManagementController.spec.ts
@@ -28,6 +28,18 @@ describe('Fetch All Categories Materials Controller ', () => {
         expect(mockResponse.status).toBeCalledWith(200);
     });
 
+    test('Invalid Remove Admin Permissions Request; user not an admin', async () => {
+        mockRequest = {
+            body: {
+                email: 'admin@potential.com',
+                operation: 'remove'
+            }
+        }
+        await controller.createPermissionUpdateRequest(mockRequest as Request, mockResponse as Response)
+        expect(mockResponse.json).toBeCalledWith("User does not have admin permissions!");
+        expect(mockResponse.status).toBeCalledWith(400);
+    });
+
     test('Valid Set User as Admin Request', async () => {
         mockRequest = {
             body: {
@@ -50,6 +62,18 @@ describe('Fetch All Categories Materials Controller ', () => {
         await controller.createPermissionUpdateRequest(mockRequest as Request, mockResponse as Response)
         expect(mockResponse.json).toBeCalledWith("Admin permissions successfully revoked");
         expect(mockResponse.status).toBeCalledWith(200);
+    });
+
+    test('Invalid Set User as Admin Request; user already admin', async () => {
+        mockRequest = {
+            body: {
+                email: 'j@kj.com',
+                operation: 'add'
+            }
+        }
+        await controller.createPermissionUpdateRequest(mockRequest as Request, mockResponse as Response)
+        expect(mockResponse.json).toBeCalledWith("User is already an administrator!");
+        expect(mockResponse.status).toBeCalledWith(400);
     });
 
     test('Invalid Admin Permissions Change; Invalid Operation', async () => {


### PR DESCRIPTION
Now when attempting to make an existing admin an admin again, or revoke admin permissions from a non-admin, a 400 bad request is returned and an appropriate message describing why.