### PR TITLE
Frontend/remove hello 387

### DIFF
--- a/Client/src/Components/NavigationMenu.tsx
+++ b/Client/src/Components/NavigationMenu.tsx
@@ -77,7 +77,7 @@ export default function NavigationMenu() {
                 </Grid>
               </ClickAwayListener>
               <Grid item>
-                <img src={universitylogo} />
+                <a href="https://concordia.ca"><img src={universitylogo} /></a>
               </Grid>
               <Grid container item xs={4} justify="flex-end">
                 <Typography variant="h6" color="inherit">

--- a/Client/src/Components/NavigationMenu.tsx
+++ b/Client/src/Components/NavigationMenu.tsx
@@ -15,6 +15,7 @@ import { loginRoute } from "../Common/Consts/Routes"
 import { removeUserInStorage } from '../Common/Storage'
 import universitylogo from './universitylogo.png'
 import { callLogout } from "../Remote/Endpoints/AuthenticationEndpoint"
+import { FormatLineSpacing } from "@material-ui/icons"
 
 const drawerWidth = linkWidth
 
@@ -55,8 +56,14 @@ export default function NavigationMenu() {
     return user && user.firstName ?
       (
         <Typography>
-          {user.firstName} {user.lastName}&nbsp;&nbsp;&nbsp;
-          <Button id="SignOut" variant="contained" onClick={logout}>Sign out</Button>
+          <Grid container spacing={2}>
+            <Grid item>
+              {user.firstName} {user.lastName}
+            </Grid>
+            <Grid>
+              <Button id="SignOut" variant="contained" onClick={logout}>Sign out</Button>
+            </Grid>
+          </Grid>
         </Typography>
       ) : (
         <Button component={Link} to={loginRoute} id='LogIn' variant="contained">Log in</Button>

--- a/Client/src/Components/NavigationMenu.tsx
+++ b/Client/src/Components/NavigationMenu.tsx
@@ -55,7 +55,7 @@ export default function NavigationMenu() {
     return user && user.firstName ?
       (
         <Typography>
-          Hello, {user.firstName} {user.lastName}
+          {user.firstName} {user.lastName}&nbsp;&nbsp;&nbsp;
           <Button id="SignOut" variant="contained" onClick={logout}>Sign out</Button>
         </Typography>
       ) : (


### PR DESCRIPTION
This branch removes the "hello" when user signs in and adds a bit of space between user's name and sign out button.

![Screenshot (282)](https://user-images.githubusercontent.com/35615793/109098318-149c9700-76ef-11eb-9e67-d89ef66f27a8.png)
