### PR TITLE
Added tab titles for each page

### DIFF
--- a/Client/src/Components/Admin/AdminReviewView.tsx
+++ b/Client/src/Components/Admin/AdminReviewView.tsx
@@ -16,7 +16,7 @@ export function AdminReviewView() {
   const [flaggedComment, setFlaggedComment] = useState("")
   const [update, setUpdate] = useState(0)
 
-  useEffect(() => { document.title = "Admin Review" })
+  useEffect(() => { document.title = "Admin Review" }, [])
 
   const handleDeleteDataset = async () => {
     await callRejectDataset(dataset.id)

--- a/Client/src/Components/Admin/AdminReviewView.tsx
+++ b/Client/src/Components/Admin/AdminReviewView.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Grid, TextField, Typography } from '@material-ui/core'
 import { IApprovedDatasetModel, IFlaggedDatasetQuery } from '../../Models/Datasets/IApprovedDatasetModel'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { approvedDataset, callRejectDataset, flagDataset } from '../../Remote/Endpoints/DatasetEndpoint'
 
 import { AdminReviewList } from './AdminReviewList'
@@ -15,6 +15,8 @@ export function AdminReviewView() {
   const [comment, setComment] = useState("")
   const [flaggedComment, setFlaggedComment] = useState("")
   const [update, setUpdate] = useState(0)
+
+  useEffect(() => { document.title = "Admin Review" })
 
   const handleDeleteDataset = async () => {
     await callRejectDataset(dataset.id)

--- a/Client/src/Components/CellSizeAnalysis/CellSizeAnalysisView.tsx
+++ b/Client/src/Components/CellSizeAnalysis/CellSizeAnalysisView.tsx
@@ -1,10 +1,13 @@
 import { Box, Typography } from '@material-ui/core'
+import React, { useEffect } from 'react'
 
-import React from 'react'
 import cellSizeAnalyzerExecutable from '../../Assets/python-3.9.2-amd64.exe'
 import cellSizeDemoGif from '../../Assets/cell-size-analysis-demo.gif'
 
 export const CellSizeAnalysisView = () => {
+
+  useEffect(() => { document.title = "Cell Size Analysis" })
+
   return (
     <>
       <Box p={5}>

--- a/Client/src/Components/CellSizeAnalysis/CellSizeAnalysisView.tsx
+++ b/Client/src/Components/CellSizeAnalysis/CellSizeAnalysisView.tsx
@@ -6,7 +6,7 @@ import cellSizeDemoGif from '../../Assets/cell-size-analysis-demo.gif'
 
 export const CellSizeAnalysisView = () => {
 
-  useEffect(() => { document.title = "Cell Size Analysis" })
+  useEffect(() => { document.title = "Cell Size Analysis" }, [])
 
   return (
     <>

--- a/Client/src/Components/DatasetUpload/DatasetView.tsx
+++ b/Client/src/Components/DatasetUpload/DatasetView.tsx
@@ -41,7 +41,7 @@ export const DatasetView = (props: IProps) => {
   const [fileUploadOpen, setFileUploadOpen] = useState(false)
   const [acceptedFileType, setAcceptedFileType] = useState(jsonType)
 
-  useEffect(() => { document.title = "Dataset Upload" })
+  useEffect(() => { document.title = "Dataset Upload" }, [])
 
   useEffect(() => {
     const getDatasetInfo = async (id: number) => {

--- a/Client/src/Components/DatasetUpload/DatasetView.tsx
+++ b/Client/src/Components/DatasetUpload/DatasetView.tsx
@@ -41,6 +41,8 @@ export const DatasetView = (props: IProps) => {
   const [fileUploadOpen, setFileUploadOpen] = useState(false)
   const [acceptedFileType, setAcceptedFileType] = useState(jsonType)
 
+  useEffect(() => { document.title = "Dataset Upload" })
+
   useEffect(() => {
     const getDatasetInfo = async (id: number) => {
       const datasetArray = await callGetDatasets({ datasetId: [id] })

--- a/Client/src/Components/FileUpload/FileUploadView.tsx
+++ b/Client/src/Components/FileUpload/FileUploadView.tsx
@@ -19,7 +19,7 @@ export const FileUploadView = (props: IProps) => {
   const { acceptedFileType } = { ...props }
   const history = useHistory()
 
-  useEffect(() => { document.title = "File Upload" })
+  useEffect(() => { document.title = "File Upload" }, [])
 
   const handleSubmit = async (jsonFile: File) => {
     try {

--- a/Client/src/Components/FileUpload/FileUploadView.tsx
+++ b/Client/src/Components/FileUpload/FileUploadView.tsx
@@ -1,13 +1,13 @@
 import { Box, Button, Container } from '@material-ui/core'
+import React, { useEffect } from 'react'
 
 import Download from '@axetroy/react-download'
 import { FileUploadForm } from './FileUploadForm'
-import React from 'react'
 import SnackbarUtils from '../Utils/SnackbarUtils'
 import { datasetRoute } from '../../Common/Consts/Routes'
+import { parseFromFile } from '../../Remote/Endpoints/FileParserEndpoint'
 import { rm } from "../../Assets/readMeMessage"
 import { useHistory } from 'react-router-dom'
-import { parseFromFile } from '../../Remote/Endpoints/FileParserEndpoint'
 
 const defaultFileFormat = 'application/json'
 
@@ -18,6 +18,8 @@ interface IProps {
 export const FileUploadView = (props: IProps) => {
   const { acceptedFileType } = { ...props }
   const history = useHistory()
+
+  useEffect(() => { document.title = "File Upload" })
 
   const handleSubmit = async (jsonFile: File) => {
     try {

--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -25,7 +25,7 @@ export default function Graph(props: IProps) {
   const { datasets, dimensions, axes } = { ...props }
   const chartRef = useRef<am4charts.XYChart>()
 
-
+  useEffect(() => { document.title = "Graph" })
   useEffect(() => initiateGraph(), [])
   useEffect(() => chartRef.current && handleUnitsUpdated(), [axes[0].units, axes[1].units, axes[0].variableName, axes[1].variableName])
   useEffect(() => chartRef.current && handleAxesScaleUpdated(), [axes[0].logarithmic, axes[1].logarithmic])

--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -25,7 +25,6 @@ export default function Graph(props: IProps) {
   const { datasets, dimensions, axes } = { ...props }
   const chartRef = useRef<am4charts.XYChart>()
 
-  useEffect(() => { document.title = "Graph" })
   useEffect(() => initiateGraph(), [])
   useEffect(() => chartRef.current && handleUnitsUpdated(), [axes[0].units, axes[1].units, axes[0].variableName, axes[1].variableName])
   useEffect(() => chartRef.current && handleAxesScaleUpdated(), [axes[0].logarithmic, axes[1].logarithmic])

--- a/Client/src/Components/Graph/Graph.tsx
+++ b/Client/src/Components/Graph/Graph.tsx
@@ -25,7 +25,6 @@ export default function Graph(props: IProps) {
   const { datasets, dimensions, axes } = { ...props }
   const chartRef = useRef<am4charts.XYChart>()
 
-  useEffect(() => initiateGraph(), [])
   useEffect(() => chartRef.current && handleUnitsUpdated(), [axes[0].units, axes[1].units, axes[0].variableName, axes[1].variableName])
   useEffect(() => chartRef.current && handleAxesScaleUpdated(), [axes[0].logarithmic, axes[1].logarithmic])
   useEffect(() => chartRef.current && handleDatasetsUpdated(), [datasets])

--- a/Client/src/Components/Graph/GraphView.tsx
+++ b/Client/src/Components/Graph/GraphView.tsx
@@ -22,6 +22,9 @@ export default function GraphView() {
   const [graphState, setGraphState] = useState<IGraphStateModel>({ ...newGraphState, id: graphStateId })
   const [dimensions, setDimensions] = useState<IDimensionModel[]>([])
 
+
+  useEffect(() => { document.title = "Graph" }, [])
+
   const getDimensions = async () => {
     const databaseDimensions = await callGetAllDimensions()
     setDimensions(databaseDimensions)

--- a/Client/src/Components/Home/AboutView.tsx
+++ b/Client/src/Components/Home/AboutView.tsx
@@ -1,12 +1,15 @@
 import { Box, Container, Grid } from '@material-ui/core'
+import React, { useEffect } from 'react'
 
-import React from 'react'
-import { classStyles } from '../../appTheme'
-import profPic from '../universitylogo.png'
 import Avatar from '@material-ui/core/Avatar';
 import LinkedInIcon from '@material-ui/icons/LinkedIn';
+import { classStyles } from '../../appTheme'
+import profPic from '../universitylogo.png'
 
 export const AboutView = () => {
+
+  useEffect(() => { document.title = "About" })
+
   return (
     <Container>
       <Grid container>

--- a/Client/src/Components/Home/AboutView.tsx
+++ b/Client/src/Components/Home/AboutView.tsx
@@ -8,7 +8,7 @@ import profPic from '../universitylogo.png'
 
 export const AboutView = () => {
 
-  useEffect(() => { document.title = "About" })
+  useEffect(() => { document.title = "About" }, [])
 
   return (
     <Container>

--- a/Client/src/Components/Home/HomeView.tsx
+++ b/Client/src/Components/Home/HomeView.tsx
@@ -6,7 +6,7 @@ import Blurb from './Blurb/Blurb'
 import Splash from './Splash/Splash'
 
 export default function HomeView(): any {
-  useEffect(() => { document.title = "Home" })
+  useEffect(() => { document.title = "Home" }, [])
   return (
     <>
       <Splash />

--- a/Client/src/Components/Home/HomeView.tsx
+++ b/Client/src/Components/Home/HomeView.tsx
@@ -1,10 +1,12 @@
 import './../../App.css'
 
+import React, { useEffect } from "react"
+
 import Blurb from './Blurb/Blurb'
-import React from "react"
 import Splash from './Splash/Splash'
 
 export default function HomeView(): any {
+  useEffect(() => { document.title = "Home" })
   return (
     <>
       <Splash />

--- a/Client/src/Components/Profile/ProfileView.tsx
+++ b/Client/src/Components/Profile/ProfileView.tsx
@@ -25,6 +25,8 @@ interface TabPanelProps {
 function TabPanel(props: TabPanelProps) {
   const { children, value, index, ...other } = props
 
+  useEffect(() => { document.title = "Profile" })
+
   return (
     <div
       role="tabpanel"

--- a/Client/src/Components/Profile/ProfileView.tsx
+++ b/Client/src/Components/Profile/ProfileView.tsx
@@ -25,7 +25,7 @@ interface TabPanelProps {
 function TabPanel(props: TabPanelProps) {
   const { children, value, index, ...other } = props
 
-  useEffect(() => { document.title = "Profile" })
+  useEffect(() => { document.title = "Profile" }, [])
 
   return (
     <div

--- a/Client/src/Components/ResearchPaperAnalysis/ResearchPaperAnalysisView.tsx
+++ b/Client/src/Components/ResearchPaperAnalysis/ResearchPaperAnalysisView.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography, useTheme } from '@material-ui/core'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { DatasetView } from '../DatasetUpload/DatasetView'
 import { FileUploadForm } from '../FileUpload/FileUploadForm'
@@ -17,6 +17,8 @@ export const ResearchPaperAnalysisView = (props: IProps) => {
 
   const [analyzedDataset, setAnalyzedDataset] = useState<IDatasetModel>(null)
   const [isProcessingPaper, setIsProcessingPaper] = useState(false)
+
+  useEffect(() => { document.title = "Research Analysis" })
 
   const handleSubmit = async (researchPaper: File): Promise<void> => {
     analyzePaper(researchPaper)

--- a/Client/src/Components/ResearchPaperAnalysis/ResearchPaperAnalysisView.tsx
+++ b/Client/src/Components/ResearchPaperAnalysis/ResearchPaperAnalysisView.tsx
@@ -18,7 +18,7 @@ export const ResearchPaperAnalysisView = (props: IProps) => {
   const [analyzedDataset, setAnalyzedDataset] = useState<IDatasetModel>(null)
   const [isProcessingPaper, setIsProcessingPaper] = useState(false)
 
-  useEffect(() => { document.title = "Research Analysis" })
+  useEffect(() => { document.title = "Research Analysis" }, [])
 
   const handleSubmit = async (researchPaper: File): Promise<void> => {
     analyzePaper(researchPaper)

--- a/Client/src/Components/Search/SearchView.tsx
+++ b/Client/src/Components/Search/SearchView.tsx
@@ -42,6 +42,8 @@ export default function SearchView(props: IProps) {
     callListDatapoints()
   }, [])
 
+  useEffect(() => { document.title = "Search" })
+
   const handleSearchClick = async (query: ISearchDatasetsFormModel) => {
     const datasets = await callGetDatasets(query) || []
     setFoundDatasets(datasets)

--- a/Client/src/Components/Search/SearchView.tsx
+++ b/Client/src/Components/Search/SearchView.tsx
@@ -42,7 +42,7 @@ export default function SearchView(props: IProps) {
     callListDatapoints()
   }, [])
 
-  useEffect(() => { document.title = "Search" })
+  useEffect(() => { document.title = "Search" }, [])
 
   const handleSearchClick = async (query: ISearchDatasetsFormModel) => {
     const datasets = await callGetDatasets(query) || []

--- a/Client/src/Components/UserReview/UserReviewView.tsx
+++ b/Client/src/Components/UserReview/UserReviewView.tsx
@@ -12,7 +12,7 @@ interface IProps {
 export const UserReviewView = (props: IProps) => {
   const [datasets, setDatasets] = useState<IApprovedDatasetModel[]>([])
 
-  useEffect(() => { document.title = "Flagged Datasets" })
+  useEffect(() => { document.title = "Flagged Datasets" }, [])
 
   useEffect(() => {
     const fetchUserDatasets = async () => {

--- a/Client/src/Components/UserReview/UserReviewView.tsx
+++ b/Client/src/Components/UserReview/UserReviewView.tsx
@@ -12,6 +12,8 @@ interface IProps {
 export const UserReviewView = (props: IProps) => {
   const [datasets, setDatasets] = useState<IApprovedDatasetModel[]>([])
 
+  useEffect(() => { document.title = "Flagged Datasets" })
+
   useEffect(() => {
     const fetchUserDatasets = async () => {
       const userDatasets: IApprovedDatasetModel[] = await getUserFlaggedDatasets()


### PR DESCRIPTION
Modified all the pages to show the correct title on the browser's tab

The following are examples of the tabs:

<img width="296" alt="Screen Shot 2021-03-15 at 11 46 23 PM" src="https://user-images.githubusercontent.com/26638534/111252970-af9ad980-85e8-11eb-9909-3fefadfea95d.png">
<img width="348" alt="Screen Shot 2021-03-15 at 11 46 18 PM" src="https://user-images.githubusercontent.com/26638534/111252972-af9ad980-85e8-11eb-923e-5992f1be67cd.png">
<img width="515" alt="Screen Shot 2021-03-15 at 11 46 12 PM" src="https://user-images.githubusercontent.com/26638534/111252974-af9ad980-85e8-11eb-8635-68222e35aeb1.png">
