### PR TITLE
Uploaded datasets API now returns IDs

### DIFF
--- a/Client/src/Remote/Endpoints/DatasetEndpoint.tsx
+++ b/Client/src/Remote/Endpoints/DatasetEndpoint.tsx
@@ -5,7 +5,7 @@ import { IDatasetModel } from "../../Models/Datasets/IDatasetModel"
 import { ISearchDatasetsFormModel } from "../../Components/Search/ISearchDatasetsFormModel"
 import SnackbarUtils from "../../Components/Utils/SnackbarUtils"
 
-const userUploadedDatasetsRoute = '/api/v1/dataset/userUploadedDatasets/:userUploadedDatasets'
+const userUploadedDatasetsRoute = '/api/v1/uploadedDatasets'
 const userSavedDatasetsRoute = '/api/v1/favoriteDatasets'
 const dataUploadRoute = '/api/v1/dataUpload'
 const datasetRoute = '/api/v1/dataset'

--- a/Server/src/migrations/SeedDatabase.ts
+++ b/Server/src/migrations/SeedDatabase.ts
@@ -545,7 +545,7 @@ export class SeedDatabase1611943920000 implements MigrationInterface {
     unitsToDelete2.id = 10;
     unitsToDelete2.conversionFormula = "{u}";
     unitsToDelete2.dimensionId = 4;
-    unitsToDelete2.name = "To be deleted";
+    unitsToDelete2.name = "To delete";
 
     let reprNone = new Representations();
     reprNone.id;

--- a/Server/src/models/DatasetModels/DatasetQueryModel.ts
+++ b/Server/src/models/DatasetModels/DatasetQueryModel.ts
@@ -137,8 +137,9 @@ export class DataQueryModel {
      * @param id 
      * Account ID: number
      */
-    async getUploadedDatasetIDOfUser(userID: number): Promise<IDatasetIDModel[]> {
+    async getUploadedDatasetIDOfUser(userID: number): Promise<any[]> {
         return selectDatasetIdsQuery(this.connection)
+            .addSelect('dataset.isApproved', 'isApproved')
             .innerJoin(Accounts, 'account', 'dataset.uploaderId = account.id')
             .where('account.id = :idRef', { idRef: userID })
             .getRawMany();

--- a/Server/src/models/interfaces/DatasetModelInterface.ts
+++ b/Server/src/models/interfaces/DatasetModelInterface.ts
@@ -73,3 +73,8 @@ export interface IApprovalDatasetModel extends IClientDatasetModel {
     datasetIsFlagged: number
     datasetFlaggedComment: string
 }
+
+export interface IUserDatasets {
+    datasetID: number
+    approved: boolean
+}

--- a/Server/src/models/interfaces/DatasetModelInterface.ts
+++ b/Server/src/models/interfaces/DatasetModelInterface.ts
@@ -75,6 +75,6 @@ export interface IApprovalDatasetModel extends IClientDatasetModel {
 }
 
 export interface IUserDatasets {
-    datasetID: number
+    datasetId: number
     approved: boolean
 }

--- a/Server/src/services/DataSetService.ts
+++ b/Server/src/services/DataSetService.ts
@@ -309,26 +309,26 @@ export class DataSetService {
   async getUserUploadedDatasets(userReceived: number) {
     try {
       let rawData = await this.dataQuery.getUploadedDatasetIDOfUser(userReceived);
-      let setOfIDs: IUserDatasets[] = []
+      let setOfIds: IUserDatasets[] = []
       if (rawData) {
-        let singleID: IUserDatasets
+        let singleId: IUserDatasets
         for (let value of rawData) {
           if (value.isApproved == 0) {
-            singleID = {
-              datasetID: value.dataset_id,
+            singleId = {
+              datasetId: value.dataset_id,
               approved: false
             }
           }
           else {
-            singleID = {
-              datasetID: value.dataset_id,
+            singleId = {
+              datasetId: value.dataset_id,
               approved: true
             }
           }
-          setOfIDs.push(singleID)
+          setOfIds.push(singleId)
         }
       }
-      this.requestResponse.message = setOfIDs as any
+      this.requestResponse.message = setOfIds as any
       this.requestResponse.statusCode = 200
       return this.requestResponse
     } catch (error) {

--- a/Server/src/tests/controllers/DatasetController.spec.ts
+++ b/Server/src/tests/controllers/DatasetController.spec.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { createConnection, getConnection } from 'typeorm';
 import { DataSetController } from '../../controllers/DataSetController';
-import { oneFavoriteDataset } from '../testData/testData';
+import { oneFavoriteDataset, oneUploadedDatasetID } from '../testData/testData';
 
 describe('Data Set Controller ', () => {
     let mockRequest;
@@ -113,7 +113,7 @@ describe('Data Set Controller ', () => {
             }
         }
         await GetDataControllerController.createRequestForUserUploadedDatasets(mockRequest as Request, mockResponse as Response)
-        expect(mockResponse.json).toBeCalledWith(oneFavoriteDataset);
+        expect(mockResponse.json).toBeCalledWith(oneUploadedDatasetID);
         expect(mockResponse.status).toBeCalledWith(200);
     });
 

--- a/Server/src/tests/models/DatasetQueryModel.spec.ts
+++ b/Server/src/tests/models/DatasetQueryModel.spec.ts
@@ -74,9 +74,10 @@ describe('data query model test', () => {
         done()
     });
 
-    test('Feeds the email of account ID of 1 and expects to see a data set ID of 1 returned', async done => {
+    test('Feeds account ID of 1 and expects to see a data set ID of 1 returned', async done => {
         let arrayOfData = await dataQueryModel.getUploadedDatasetIDOfUser(1)
         expect(arrayOfData[0].dataset_id).toEqual(1);
+        expect(arrayOfData[0].isApproved).toEqual(0);
         done()
     });
 

--- a/Server/src/tests/services/DataSetService.spec.ts
+++ b/Server/src/tests/services/DataSetService.spec.ts
@@ -177,16 +177,16 @@ describe('data set service test', () => {
 
   test('Feeds account ID of 3 and expects to see an approved uploaded data set with ID of 2 returned', async done => {
     let response = await retrieveDataObject.getUserUploadedDatasets(3)
-    let arrayOfData = response.message as unknown as IUserDatasets[]
-    expect(arrayOfData[0].datasetID).toEqual(2);
+    let arrayOfData = response.message as IUserDatasets[]
+    expect(arrayOfData[0].datasetId).toEqual(2);
     expect(arrayOfData[0].approved).toEqual(true);
     done()
   });
 
   test('Feeds account ID of 1 and expects to see an unapproved uploaded data set with ID of 1 returned', async done => {
     let response = await retrieveDataObject.getUserUploadedDatasets(1)
-    let arrayOfData = response.message as unknown as IUserDatasets[]
-    expect(arrayOfData[0].datasetID).toEqual(1);
+    let arrayOfData = response.message as IUserDatasets[]
+    expect(arrayOfData[0].datasetId).toEqual(1);
     expect(arrayOfData[0].approved).toEqual(false);
     done()
   });
@@ -244,7 +244,7 @@ describe('data set service test', () => {
 
   test('Asks for all flagged data sets expects a data set with ID of 1', async done => {
     let response = await retrieveDataObject.getAllFlaggedDatasets()
-    let arrayOfData = response.message as unknown as IApprovalDatasetModel[]
+    let arrayOfData = response.message as IApprovalDatasetModel[]
     expect(arrayOfData[0].id).toEqual(1);
     expect(response.statusCode).toEqual(200);
     done()
@@ -252,7 +252,7 @@ describe('data set service test', () => {
 
   test('Asks for all flagged data sets of account ID 1, expects a data set with ID of 1', async done => {
     let response = await retrieveDataObject.getUserFlaggedDatasets(1)
-    let arrayOfData = response.message as unknown as IApprovalDatasetModel[]
+    let arrayOfData = response.message as IApprovalDatasetModel[]
     expect(arrayOfData[0].id).toEqual(1);
     expect(response.statusCode).toEqual(200);
     done()

--- a/Server/src/tests/services/DataSetService.spec.ts
+++ b/Server/src/tests/services/DataSetService.spec.ts
@@ -1,7 +1,7 @@
 import { createConnection, getConnection } from 'typeorm';
 
 import { DataSetService } from "../../services/DataSetService";
-import { IApprovalDatasetModel } from "../../models/interfaces/DatasetModelInterface";
+import { IApprovalDatasetModel, IUserDatasets } from "../../models/interfaces/DatasetModelInterface";
 import { IDataRequestModel } from "../../models/interfaces/DataRequestModelInterface";
 
 describe('data set service test', () => {
@@ -175,10 +175,26 @@ describe('data set service test', () => {
     done()
   });
 
-  test('Feeds account ID of 3 and expects to see an uploaded data set with ID of 2 returned', async done => {
+  test('Feeds account ID of 3 and expects to see an approved uploaded data set with ID of 2 returned', async done => {
     let response = await retrieveDataObject.getUserUploadedDatasets(3)
-    let arrayOfData = response.message as unknown as IApprovalDatasetModel[]
-    expect(arrayOfData[0].id).toEqual(2);
+    let arrayOfData = response.message as unknown as IUserDatasets[]
+    expect(arrayOfData[0].datasetID).toEqual(2);
+    expect(arrayOfData[0].approved).toEqual(true);
+    done()
+  });
+
+  test('Feeds account ID of 1 and expects to see an unapproved uploaded data set with ID of 1 returned', async done => {
+    let response = await retrieveDataObject.getUserUploadedDatasets(1)
+    let arrayOfData = response.message as unknown as IUserDatasets[]
+    expect(arrayOfData[0].datasetID).toEqual(1);
+    expect(arrayOfData[0].approved).toEqual(false);
+    done()
+  });
+
+  test('Feeds non-existant account ID of -1 and expects to see a blank array returned', async done => {
+    let response = await retrieveDataObject.getUserUploadedDatasets(-1)
+    let arrayOfData = response.message
+    expect(arrayOfData).toEqual([]);
     done()
   });
 

--- a/Server/src/tests/testData/dimensionTestData.ts
+++ b/Server/src/tests/testData/dimensionTestData.ts
@@ -116,7 +116,7 @@ export const availableDBDimensions =
           "conversionFormula": "{u}",
           "dimensionId": 4,
           "id": 10,
-          "name": "To be deleted",
+          "name": "To delete",
         },
       ],
     }

--- a/Server/src/tests/testData/testData.ts
+++ b/Server/src/tests/testData/testData.ts
@@ -577,7 +577,7 @@ export const oneFavoriteDataset = [
 
 export const oneUploadedDatasetID = [
     {
-        "datasetID": 2,
+        "datasetId": 2,
         "approved": true
     }
 ]

--- a/Server/src/tests/testData/testData.ts
+++ b/Server/src/tests/testData/testData.ts
@@ -574,3 +574,10 @@ export const oneFavoriteDataset = [
         },
     }
 ]
+
+export const oneUploadedDatasetID = [
+    {
+        "datasetID": 2,
+        "approved": true
+    }
+]


### PR DESCRIPTION
Previously the uploadedDatasets API call returned full data sets and now it returns the data set IDs and the approval status of these data sets. 