### PR TITLE
Fix local unit testing causing test files to be deleted

### DIFF
--- a/Server/src/services/Parser/FileHandlerFactory.ts
+++ b/Server/src/services/Parser/FileHandlerFactory.ts
@@ -17,14 +17,16 @@ export abstract class AbstractFileExtractor {
   abstract parseFile()
 
   async deleteFile(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      fileSystem.unlink(this.filePath, (error) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve()
-        }
+    if (process.env.NODE_ENV !== 'test') {
+      return new Promise((resolve, reject) => {
+        fileSystem.unlink(this.filePath, (error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
+        })
       })
-    })
+    }
   }
 }

--- a/Server/src/tests/services/FileParserService.spec.ts
+++ b/Server/src/tests/services/FileParserService.spec.ts
@@ -30,7 +30,7 @@ describe('Data Parser Service', () => {
     })
 
     test('Invalid - Request to Extract a non-existing file', async () => {
-        let res = "ENOENT: no such file or directory, unlink ''"
+        let res = "Cannot parse your file. Something is wrong with it"
         let extension = 'json'
         let filePath = ''
         dataParserService = new DataParserService(extension, filePath)


### PR DESCRIPTION
This PR uses the environment variable to determine if it's in a test state or not and if it is, it won't remove the unit test files