### PR TITLE
Name on search result now links to dataset page.

### DIFF
--- a/Client/src/Components/Search/SearchResults.tsx
+++ b/Client/src/Components/Search/SearchResults.tsx
@@ -1,10 +1,11 @@
 import { ColDef, DataGrid, SelectionChangeParams, ValueGetterParams } from '@material-ui/data-grid'
-import { Grid, List, ListItem, ListItemText } from '@material-ui/core'
+import { Grid, List, ListItem, ListItemText, Typography } from '@material-ui/core'
 import { IData, IDatasetModel, IReference } from "../../Models/Datasets/IDatasetModel"
 
 import { DatasetFormModal } from '../DatasetUpload/DatasetViewModal'
-import React from 'react'
 import { ICategoryModel } from '../../Models/Profile/ICategoryModel'
+import { Link } from 'react-router-dom'
+import React from 'react'
 
 interface IProps {
   datasetResults: IDatasetModel[],
@@ -36,6 +37,18 @@ export const SearchResults = (props: IProps) => {
     return `${reference.year}`
   }
 
+  const getNameLink = (params: ValueGetterParams) => {
+    const datasetID = params.getValue('id')
+    const datasetName = params.getValue('dataset_name')
+    return (
+      <Link to={'/dataset/' + datasetID} >
+        <Typography>
+          {datasetName}
+        </Typography>
+      </Link>
+    )
+  }
+
   const getCategoryId = (params: ValueGetterParams) => {
     const categoryId = params.row.category
     const foundCategory = categories.find(category => category.id == categoryId)
@@ -64,21 +77,21 @@ export const SearchResults = (props: IProps) => {
     )
   }
 
-  const linkToDataset = (params: ValueGetterParams) => {
+  const linkToDatasetModal = (params: ValueGetterParams) => {
     const datasetId = params.getValue('id')
 
     return (<DatasetFormModal datasetId={datasetId.toString()} />)
   }
 
   const columns: ColDef[] = [
-    { field: 'dataset_name', headerName: 'Name', flex: 1 },
+    { field: 'dataset_name', headerName: 'Name', renderCell: getNameLink, flex: 1 },
     { field: `title`, headerName: 'Title', valueGetter: getTitle, flex: 1 },
     { field: 'category', headerName: 'Category', flex: 1, valueGetter: getCategoryId },
     { field: 'subcategory', headerName: 'SubCategory', flex: 1, valueGetter: getSubcategoryId },
     { field: 'author', headerName: 'Author', flex: 1, valueGetter: getAuthor },
     { field: 'year', headerName: 'Year', flex: 1, valueGetter: getYear },
     { field: 'variables', headerName: 'List Of Variables', flex: 2, renderCell: getVariableList },
-    { field: 'dataset_button', headerName: 'View', flex: 1, renderCell: linkToDataset },
+    { field: 'dataset_button', headerName: 'View', flex: 1, renderCell: linkToDatasetModal },
   ]
 
   return (


### PR DESCRIPTION
After searching for datasets, you can click the name to go to the dataset page. Clicking the link still renders the modal.

![image](https://user-images.githubusercontent.com/46732530/114104114-467d4d80-9898-11eb-87e1-5c21807db49a.png)

![image](https://user-images.githubusercontent.com/46732530/114104122-4bda9800-9898-11eb-91e7-f1c000069eea.png)
