### PR TITLE
Fixed issue where admins would by default use the handle edit endpoint when creating a dataset.

### DIFF
--- a/Client/src/Components/DatasetUpload/DatasetView.tsx
+++ b/Client/src/Components/DatasetUpload/DatasetView.tsx
@@ -7,6 +7,7 @@ import { useHistory, useParams } from "react-router"
 
 import { DatasetForm } from './DatasetForm/DatasetForm'
 import { DefaultFormFooter } from '../Forms/DefaultFormFooter'
+import { DownloadFileTypeModal } from './DownloadFileTypeModal'
 import { FavoriteDatasetButton } from './FavoriteDatasetButton'
 import { FileTypePromptModal } from './FileTypePromptModal'
 import { FileUploadModal } from './FileUploadModal'
@@ -25,7 +26,6 @@ import { useEffect } from 'react'
 import { useLocation } from "react-router-dom"
 import { useState } from 'react'
 import { useTitle } from '../../Common/Hooks/useTitle'
-import { DownloadFileTypeModal } from './DownloadFileTypeModal'
 import { useUserSelector } from '../../Stores/Slices/UserSlice'
 
 interface IProps {
@@ -84,7 +84,7 @@ export const DatasetView = (props: IProps) => {
   }, [])
 
   const handleSubmitForm = async (formDataset: IDatasetModel) => {
-    if (user.account_permissions == 2) {
+    if (user.account_permissions == 2 && datasetID) {
       const newApprovalDatset: IApprovedDatasetModel = { ...formDataset, datasetFlaggedComment: null, datasetIsFlagged: null }
       await submitEditedDataset(newApprovalDatset)
       SnackbarUtils.success("Dataset successfully uploaded")


### PR DESCRIPTION
Previously, if a user was an admin and they tried to submit a new dataset, it would treat it as though they were editing an already existing dataset. This PR adds a check so that if the dataset ID is not set, it will created a new one.